### PR TITLE
Update module path and URLs for the account rename to unmaykr-a

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 andri1305
+Copyright (c) 2026 unmaykr-a
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All you need is Docker and the compose file — no cloning, no building:
 
 ```bash
 mkdir taskrr && cd taskrr
-curl -LO https://raw.githubusercontent.com/andri1305/taskrr/main/docker-compose.yml
+curl -LO https://raw.githubusercontent.com/unmaykr-a/taskrr/main/docker-compose.yml
 mkdir data
 docker compose up -d
 ```
@@ -86,7 +86,7 @@ beyond your own LAN: set `TASKRR_COOKIE_SECURE=true` there.
 Needs Go 1.25+ and Node 22+:
 
 ```bash
-git clone https://github.com/andri1305/taskrr.git
+git clone https://github.com/unmaykr-a/taskrr.git
 cd taskrr
 make build           # frontend + backend -> bin/taskrr
 ./bin/taskrr         # serves on :8787, data in ./data

--- a/cmd/taskrr/main.go
+++ b/cmd/taskrr/main.go
@@ -16,12 +16,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/api"
-	"github.com/andri1305/taskrr/internal/auth"
-	"github.com/andri1305/taskrr/internal/config"
-	"github.com/andri1305/taskrr/internal/logbuf"
-	"github.com/andri1305/taskrr/internal/reminder"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/api"
+	"github.com/unmaykr-a/taskrr/internal/auth"
+	"github.com/unmaykr-a/taskrr/internal/config"
+	"github.com/unmaykr-a/taskrr/internal/logbuf"
+	"github.com/unmaykr-a/taskrr/internal/reminder"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # This file is all you need to run it:
 #
 #   mkdir taskrr && cd taskrr
-#   curl -LO https://raw.githubusercontent.com/andri1305/taskrr/main/docker-compose.yml
+#   curl -LO https://raw.githubusercontent.com/unmaykr-a/taskrr/main/docker-compose.yml
 #   mkdir data
 #   docker compose up -d
 #
@@ -21,7 +21,7 @@
 
 services:
   taskrr:
-    image: ghcr.io/andri1305/taskrr:latest
+    image: ghcr.io/unmaykr-a/taskrr:latest
     container_name: taskrr
     restart: unless-stopped
     user: "${TASKRR_UID:-1000}:${TASKRR_GID:-1000}"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/andri1305/taskrr
+module github.com/unmaykr-a/taskrr
 
 go 1.25.0
 

--- a/internal/api/account_self_test.go
+++ b/internal/api/account_self_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // authed returns a request with the given user injected into the context, as the

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -16,9 +16,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/andri1305/taskrr/internal/auth"
-	"github.com/andri1305/taskrr/internal/logbuf"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/auth"
+	"github.com/unmaykr-a/taskrr/internal/logbuf"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 const sessionCookie = "taskrr_session"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // hexColor matches the "#rrggbb" form the colour inputs produce. We validate so

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/auth"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/auth"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // signIn creates a real session for u and returns the cookie a browser would

--- a/internal/api/lite_test.go
+++ b/internal/api/lite_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 func TestLiteModeDisablesMultiUser(t *testing.T) {

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/andri1305/taskrr/internal/logbuf"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/logbuf"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 func TestHandleListLogs(t *testing.T) {

--- a/internal/api/merge_test.go
+++ b/internal/api/merge_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // mergeCall invokes the merge handler as the given admin and returns the recorder.

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -15,7 +15,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // OIDC settings keys (admin-editable; seeded from env at bootstrap).

--- a/internal/api/oidc_role_test.go
+++ b/internal/api/oidc_role_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // openStore opens a real (temp-file) store for the api-level tests.

--- a/internal/api/reminders.go
+++ b/internal/api/reminders.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/andri1305/taskrr/internal/reminder"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/reminder"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // maxLeadSeconds caps how far ahead of a due time a reminder may fire (90 days).

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/logbuf"
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/logbuf"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // TaskStore is the per-user task/completion surface the HTTP layer needs. Every

--- a/internal/api/sessions_test.go
+++ b/internal/api/sessions_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 func TestHandleTerminateSessions(t *testing.T) {

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/andri1305/taskrr/internal/web"
+	"github.com/unmaykr-a/taskrr/internal/web"
 )
 
 // placeholderHTML is shown when the frontend has not been built yet (e.g. when

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -28,7 +28,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // Store is the slice of the data layer the reminder loop needs.

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andri1305/taskrr/internal/store"
+	"github.com/unmaykr-a/taskrr/internal/store"
 )
 
 // testService allows loopback so Tick logic can be exercised against an httptest


### PR DESCRIPTION
Follow-up to the account rename (andri1305 -> unmaykr-a). Updates every reference in the repo:

- **Go module path**: `module github.com/unmaykr-a/taskrr` in go.mod, with all internal imports across 16 Go files updated to match. Verified with `go vet` and the full test suite.
- **docker-compose.yml**: pulls `ghcr.io/unmaykr-a/taskrr:latest`, and the curl quick-start URL in the header comment points at the new account.
- **README**: clone and raw-compose URLs.
- **LICENSE**: copyright holder name.

No change needed in `.github/workflows/release.yml` — it derives the image name from `${{ github.repository }}`, so it already publishes to `ghcr.io/unmaykr-a/taskrr`.

One note: GitHub redirects the old `andri1305` URLs to the new ones (until someone claims the old username), so previously copied compose files keep working, but the GHCR image name does NOT redirect — anyone who copied the compose before this change should re-copy it once the rename lands.

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_