### PR TITLE
Add static GitHub Pages demo with in-browser API mock

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,59 @@
+name: Demo (GitHub Pages)
+
+# Builds the static, server-less demo (VITE_DEMO=1) and publishes it to GitHub
+# Pages at https://<owner>.github.io/taskrr/. The demo swaps the API layer for
+# an in-browser mock (see web/src/lib/api.demo.ts), so there is no backend to
+# run and every visitor gets their own localStorage sandbox.
+#
+# Pages must be enabled for the repo (Settings -> Pages -> Source: GitHub
+# Actions). Run manually from the Actions tab (workflow_dispatch) to preview, or
+# let a push to main publish automatically.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; let an in-progress run finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build demo bundle
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run build:demo
+        env:
+          VITE_DEMO: "1"
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          # Path is relative to the workspace root (not the job's working-directory).
+          path: web/dist-demo
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /internal/web/dist/*
 !/internal/web/dist/.gitkeep
 
+# Static demo build output (deployed to GitHub Pages, never committed)
+/web/dist-demo/
+
 # Node
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ The whole app is one ~12 MB binary with the web UI and SQLite database baked
 in. It idles at a few megabytes of memory and effectively zero CPU, so it runs
 happily in the corner of a Raspberry Pi or any small box you already have.
 
+## Live demo
+
+**[Try Taskrr in your browser →](https://unmaykr-a.github.io/taskrr/)**
+
+The demo is the real UI with no backend: it runs against an in-browser mock of
+the API, seeded with sample tasks and history, and saves everything to your
+browser's local storage. There's no account and no server — every visitor gets
+their own private sandbox, and the in-app "Reset demo" button clears it. (The
+admin area, single sign-on, backups and reminder delivery need a real server, so
+they're not part of the demo.)
+
 ## Quick start
 
 All you need is Docker and the compose file — no cloning, no building:

--- a/web/package.json
+++ b/web/package.json
@@ -1,11 +1,12 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build && node -e \"require('fs').writeFileSync('../internal/web/dist/.gitkeep','')\"",
+    "build:demo": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/web/src/components/DemoBanner.tsx
+++ b/web/src/components/DemoBanner.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { Github, Info, RotateCcw, X } from "lucide-react";
+
+import { DEMO } from "@/lib/demo";
+import { DEMO_KEYS } from "@/lib/api.demo";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+/**
+ * A small fixed notice shown only in the static GitHub Pages demo (`__DEMO__`).
+ * It makes clear there's no server — changes live in this browser only — and
+ * offers a one-click reset that wipes the local sandbox back to the seed data.
+ *
+ * Renders nothing in normal (server-backed) builds.
+ */
+export function DemoBanner() {
+  const [dismissed, setDismissed] = useState(false);
+  if (!DEMO || dismissed) return null;
+
+  const reset = () => {
+    try {
+      for (const key of DEMO_KEYS) localStorage.removeItem(key);
+    } catch {
+      // storage unavailable — nothing to clear
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-4 left-4 z-[60] max-w-[calc(100vw-2rem)] rounded-xl border bg-card/95 p-3 shadow-2xl backdrop-blur",
+        "animate-in fade-in-0 slide-in-from-bottom-2 duration-300",
+      )}
+    >
+      <div className="flex items-start gap-2.5">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+        <div className="min-w-0 text-xs">
+          <p className="font-medium text-foreground">You're viewing the Taskrr demo</p>
+          <p className="mt-0.5 text-muted-foreground">
+            There's no server here — everything you do is saved only in this browser.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Button variant="outline" size="sm" className="h-7 px-2 text-xs" onClick={reset}>
+              <RotateCcw className="h-3.5 w-3.5" /> Reset demo
+            </Button>
+            <a
+              href="https://github.com/unmaykr-a/taskrr"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-xs hover:bg-accent"
+            >
+              <Github className="h-3.5 w-3.5" /> Source
+            </a>
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => setDismissed(true)}
+          className="-mr-1 -mt-1 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Gate.tsx
+++ b/web/src/components/Gate.tsx
@@ -4,6 +4,7 @@ import App from "@/App";
 import { useAuth } from "@/components/AuthProvider";
 import { AuthPage } from "@/components/AuthPage";
 import { Background } from "@/components/Background";
+import { DemoBanner } from "@/components/DemoBanner";
 
 /**
  * Gate decides what to render based on auth state: a brief splash while we check
@@ -25,6 +26,7 @@ export function Gate() {
       ) : (
         <AuthPage />
       )}
+      <DemoBanner />
     </>
   );
 }

--- a/web/src/lib/api.demo.ts
+++ b/web/src/lib/api.demo.ts
@@ -1,0 +1,528 @@
+// In-browser mock of the Taskrr API, used only by the static GitHub Pages demo
+// (the `__DEMO__` build). It implements the exact same surface as the real HTTP
+// client in api.ts, so every component, query and mutation works unchanged — the
+// only swap happens at the single seam at the bottom of api.ts.
+//
+// There is no server: tasks, completions and preferences live in localStorage,
+// seeded on first visit with a realistic spread of tasks and history (relative
+// to "now", so the demo always looks alive). Every visitor gets their own
+// private sandbox; a "Reset demo" control wipes it (see DemoBanner).
+//
+// Server-only/admin features (users, sessions, logs, backups, OIDC, reminders
+// delivery) are stubbed: the demo account is a plain user, so the admin UI is
+// hidden, and the few self-service calls that remain resolve harmlessly.
+
+import type {
+  Activity,
+  Api,
+  AuthConfig,
+  Completion,
+  ReminderSettings,
+  Task,
+  TaskInput,
+  User,
+} from "./api";
+
+const DAY = 86_400;
+const HOUR = 3_600;
+
+// --- persistence -----------------------------------------------------------
+
+const DB_KEY = "taskrr-demo-db";
+const PREFS_KEY = "taskrr-demo-prefs";
+const SESSION_KEY = "taskrr-demo-session"; // "out" once signed out, else signed in
+const USERNAME_KEY = "taskrr-demo-username";
+
+/** All localStorage keys this demo owns — cleared by the banner's reset. */
+export const DEMO_KEYS = [DB_KEY, PREFS_KEY, SESSION_KEY, USERNAME_KEY];
+
+interface StoredTask {
+  id: number;
+  name: string;
+  description: string;
+  intervalSeconds: number | null;
+  colorFresh: string | null;
+  colorOverdue: string | null;
+  freezeColor: boolean;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface StoredCompletion {
+  id: number;
+  taskId: number;
+  completedAt: string;
+  note: string;
+  createdAt: string;
+}
+
+interface DB {
+  tasks: StoredTask[];
+  completions: StoredCompletion[];
+  nextTaskId: number;
+  nextCompletionId: number;
+}
+
+function loadDB(): DB {
+  try {
+    const raw = localStorage.getItem(DB_KEY);
+    if (raw) return JSON.parse(raw) as DB;
+  } catch {
+    // corrupt or unavailable — fall through to a fresh seed
+  }
+  const seeded = seed();
+  saveDB(seeded);
+  return seeded;
+}
+
+function saveDB(db: DB) {
+  try {
+    localStorage.setItem(DB_KEY, JSON.stringify(db));
+  } catch {
+    // storage disabled / private mode — the demo still works for this session
+  }
+}
+
+// --- seed data --------------------------------------------------------------
+
+const iso = (secondsAgo: number) => new Date(Date.now() - secondsAgo * 1000).toISOString();
+
+/** A task to seed, plus the ages (in seconds-ago) of its logged completions. */
+interface SeedTask {
+  name: string;
+  description?: string;
+  intervalSeconds: number | null;
+  freezeColor?: boolean;
+  colorFresh?: string | null;
+  colorOverdue?: string | null;
+  archived?: boolean;
+  /** Completion ages in seconds-ago, newest first. */
+  log: number[];
+  /** Optional notes keyed by index into `log`. */
+  notes?: Record<number, string>;
+}
+
+// A spread that lands tasks across fresh / due-soon / overdue and keeps the
+// last ~30 days busy so the calendar and activity chart look populated.
+const SEED: SeedTask[] = [
+  {
+    name: "Water the plants",
+    description: "The big ones by the window get thirsty fast.",
+    intervalSeconds: 3 * DAY,
+    log: [2 * DAY + 4 * HOUR, 5 * DAY, 8 * DAY, 11 * DAY, 15 * DAY, 18 * DAY, 22 * DAY, 27 * DAY],
+    notes: { 2: "skipped the succulents" },
+  },
+  {
+    name: "Change bed sheets",
+    intervalSeconds: 7 * DAY,
+    log: [20 * HOUR, 7 * DAY, 14 * DAY, 22 * DAY, 30 * DAY],
+  },
+  {
+    name: "Clean the litter box",
+    description: "Scoop daily, full change weekly.",
+    intervalSeconds: 1 * DAY,
+    log: [2 * DAY + 2 * HOUR, 3 * DAY, 4 * DAY, 5 * DAY, 6 * DAY, 7 * DAY, 8 * DAY, 9 * DAY, 10 * DAY],
+  },
+  {
+    name: "Back up the NAS",
+    description: "Pull a fresh snapshot to the offsite drive.",
+    intervalSeconds: 14 * DAY,
+    log: [3 * DAY, 17 * DAY, 32 * DAY, 47 * DAY],
+    notes: { 0: "all volumes verified" },
+  },
+  {
+    name: "Replace the water filter",
+    intervalSeconds: 30 * DAY,
+    log: [28 * DAY, 59 * DAY, 90 * DAY],
+  },
+  {
+    name: "Vacuum the apartment",
+    intervalSeconds: 5 * DAY,
+    log: [6 * DAY, 11 * DAY, 16 * DAY, 21 * DAY, 26 * DAY],
+  },
+  {
+    name: "Call grandma",
+    description: "She likes Sunday afternoons.",
+    intervalSeconds: 14 * DAY,
+    log: [10 * DAY, 24 * DAY, 39 * DAY],
+    notes: { 0: "told her about the new job" },
+  },
+  {
+    name: "Descale the coffee machine",
+    intervalSeconds: 60 * DAY,
+    log: [70 * DAY, 132 * DAY],
+  },
+  {
+    name: "Water the herb garden",
+    description: "Basil sulks if it dries out.",
+    intervalSeconds: 2 * DAY,
+    freezeColor: true,
+    colorFresh: "#10b981",
+    log: [18 * HOUR, 2 * DAY + 6 * HOUR, 4 * DAY, 6 * DAY, 9 * DAY, 12 * DAY],
+  },
+  {
+    name: "Check the smoke alarms",
+    intervalSeconds: 365 * DAY,
+    log: [210 * DAY],
+  },
+  {
+    name: "Read before bed",
+    description: "Just tracking the streak — no schedule.",
+    intervalSeconds: null,
+    log: [16 * HOUR, 2 * DAY, 3 * DAY, 5 * DAY, 6 * DAY, 9 * DAY, 12 * DAY, 13 * DAY, 19 * DAY, 25 * DAY],
+  },
+  {
+    name: "Winterize the garden hose",
+    description: "Archived until the cold comes back.",
+    intervalSeconds: 365 * DAY,
+    archived: true,
+    log: [190 * DAY],
+  },
+];
+
+function seed(): DB {
+  const tasks: StoredTask[] = [];
+  const completions: StoredCompletion[] = [];
+  let taskId = 1;
+  let completionId = 1;
+
+  for (const s of SEED) {
+    const id = taskId++;
+    // Created a little before its oldest completion so timestamps stay coherent.
+    const oldest = s.log.length ? Math.max(...s.log) : 0;
+    tasks.push({
+      id,
+      name: s.name,
+      description: s.description ?? "",
+      intervalSeconds: s.intervalSeconds,
+      colorFresh: s.colorFresh ?? null,
+      colorOverdue: s.colorOverdue ?? null,
+      freezeColor: s.freezeColor ?? false,
+      archivedAt: s.archived ? iso(oldest + DAY) : null,
+      createdAt: iso(oldest + 2 * DAY),
+      updatedAt: iso(oldest + 2 * DAY),
+    });
+    for (const ageIdx of s.log.keys()) {
+      const age = s.log[ageIdx];
+      completions.push({
+        id: completionId++,
+        taskId: id,
+        completedAt: iso(age),
+        note: s.notes?.[ageIdx] ?? "",
+        createdAt: iso(age),
+      });
+    }
+  }
+
+  return { tasks, completions, nextTaskId: taskId, nextCompletionId: completionId };
+}
+
+// --- derivation -------------------------------------------------------------
+
+/** Project a stored task into the API `Task` shape (with derived fields). */
+function toTask(db: DB, t: StoredTask): Task {
+  const mine = db.completions.filter((c) => c.taskId === t.id);
+  let last: string | null = null;
+  for (const c of mine) if (last == null || c.completedAt > last) last = c.completedAt;
+  return {
+    id: t.id,
+    name: t.name,
+    description: t.description,
+    intervalSeconds: t.intervalSeconds,
+    colorFresh: t.colorFresh,
+    colorOverdue: t.colorOverdue,
+    freezeColor: t.freezeColor,
+    archivedAt: t.archivedAt,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt,
+    lastCompletedAt: last,
+    completionCount: mine.length,
+  };
+}
+
+function toCompletion(c: StoredCompletion): Completion {
+  return { id: c.id, taskId: c.taskId, completedAt: c.completedAt, note: c.note, createdAt: c.createdAt };
+}
+
+function findTask(db: DB, id: number): StoredTask {
+  const t = db.tasks.find((x) => x.id === id);
+  if (!t) throw new Error("Task not found");
+  return t;
+}
+
+/** Small latency so optimistic UI / loading states are visible, as on a server. */
+const tick = <T>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), 80));
+
+// --- session ----------------------------------------------------------------
+
+function demoUser(): User {
+  let username = "demo";
+  try {
+    username = localStorage.getItem(USERNAME_KEY) || "demo";
+  } catch {
+    // ignore
+  }
+  return {
+    id: 1,
+    username,
+    role: "user",
+    passwordSet: true,
+    oidcLinked: false,
+    protected: false,
+    createdAt: iso(120 * DAY),
+    updatedAt: iso(120 * DAY),
+  };
+}
+
+function signedIn(): boolean {
+  try {
+    return localStorage.getItem(SESSION_KEY) !== "out";
+  } catch {
+    return true;
+  }
+}
+
+function setSession(open: boolean) {
+  try {
+    if (open) localStorage.removeItem(SESSION_KEY);
+    else localStorage.setItem(SESSION_KEY, "out");
+  } catch {
+    // ignore
+  }
+}
+
+const DEMO_AUTH: AuthConfig = {
+  localRegistration: true,
+  oidc: false,
+  requiresApproval: false,
+  lite: false,
+  defaultTheme: null,
+};
+
+const DEMO_REMINDERS: ReminderSettings = { enabled: false, webhookUrl: "", leadSeconds: 0 };
+
+const notAvailable = (): never => {
+  throw new Error("Not available in the demo.");
+};
+
+// --- the mock client --------------------------------------------------------
+
+export const demoApi: Api = {
+  // --- tasks ---
+  listTasks: () => {
+    const db = loadDB();
+    return tick(db.tasks.map((t) => toTask(db, t)));
+  },
+
+  createTask: (input: TaskInput) => {
+    const db = loadDB();
+    const now = new Date().toISOString();
+    const t: StoredTask = {
+      id: db.nextTaskId++,
+      name: input.name,
+      description: input.description ?? "",
+      intervalSeconds: input.intervalSeconds ?? null,
+      colorFresh: input.colorFresh ?? null,
+      colorOverdue: input.colorOverdue ?? null,
+      freezeColor: input.freezeColor ?? false,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    db.tasks.push(t);
+    saveDB(db);
+    return tick(toTask(db, t));
+  },
+
+  updateTask: (id: number, input: TaskInput) => {
+    const db = loadDB();
+    const t = findTask(db, id);
+    if (input.name !== undefined) t.name = input.name;
+    if (input.description !== undefined) t.description = input.description;
+    if (input.intervalSeconds !== undefined) t.intervalSeconds = input.intervalSeconds;
+    if (input.colorFresh !== undefined) t.colorFresh = input.colorFresh;
+    if (input.colorOverdue !== undefined) t.colorOverdue = input.colorOverdue;
+    if (input.freezeColor !== undefined) t.freezeColor = input.freezeColor;
+    t.updatedAt = new Date().toISOString();
+    saveDB(db);
+    return tick(toTask(db, t));
+  },
+
+  deleteTask: (id: number) => {
+    const db = loadDB();
+    db.tasks = db.tasks.filter((t) => t.id !== id);
+    db.completions = db.completions.filter((c) => c.taskId !== id);
+    saveDB(db);
+    return tick(undefined);
+  },
+
+  archiveTask: (id: number) => {
+    const db = loadDB();
+    const t = findTask(db, id);
+    t.archivedAt = new Date().toISOString();
+    t.updatedAt = t.archivedAt;
+    saveDB(db);
+    return tick(toTask(db, t));
+  },
+
+  unarchiveTask: (id: number) => {
+    const db = loadDB();
+    const t = findTask(db, id);
+    t.archivedAt = null;
+    t.updatedAt = new Date().toISOString();
+    saveDB(db);
+    return tick(toTask(db, t));
+  },
+
+  completeTask: (id: number, input: { note?: string; completedAt?: string }) => {
+    const db = loadDB();
+    findTask(db, id); // validate
+    const when = input.completedAt ?? new Date().toISOString();
+    const c: StoredCompletion = {
+      id: db.nextCompletionId++,
+      taskId: id,
+      completedAt: when,
+      note: input.note ?? "",
+      createdAt: new Date().toISOString(),
+    };
+    db.completions.push(c);
+    saveDB(db);
+    return tick(toCompletion(c));
+  },
+
+  quickComplete: (id: number) => demoApi.completeTask(id, {}),
+
+  listCompletions: (id: number) => {
+    const db = loadDB();
+    const mine = db.completions
+      .filter((c) => c.taskId === id)
+      .sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+    return tick(mine.map(toCompletion));
+  },
+
+  deleteCompletion: (id: number) => {
+    const db = loadDB();
+    db.completions = db.completions.filter((c) => c.id !== id);
+    saveDB(db);
+    return tick(undefined);
+  },
+
+  updateCompletion: (id: number, input: { completedAt: string; note?: string }) => {
+    const db = loadDB();
+    const c = db.completions.find((x) => x.id === id);
+    if (!c) throw new Error("Completion not found");
+    c.completedAt = input.completedAt;
+    c.note = input.note ?? "";
+    saveDB(db);
+    return tick(toCompletion(c));
+  },
+
+  listActivity: (fromISO: string, toISO: string) => {
+    const db = loadDB();
+    const byId = new Map(db.tasks.map((t) => [t.id, t.name]));
+    const rows: Activity[] = db.completions
+      .filter((c) => c.completedAt >= fromISO && c.completedAt <= toISO)
+      .map((c) => ({
+        completionId: c.id,
+        taskId: c.taskId,
+        taskName: byId.get(c.taskId) ?? "(deleted task)",
+        completedAt: c.completedAt,
+        note: c.note,
+      }));
+    return tick(rows);
+  },
+
+  // --- auth ---
+  authConfig: () => tick(DEMO_AUTH),
+  me: () => tick(signedIn() ? demoUser() : null),
+  login: (username: string) => {
+    setSession(true);
+    try {
+      if (username.trim()) localStorage.setItem(USERNAME_KEY, username.trim());
+    } catch {
+      // ignore
+    }
+    return tick(demoUser());
+  },
+  claim: (username: string) => demoApi.login(username, "") as Promise<User>,
+  logout: () => {
+    setSession(false);
+    return tick(undefined);
+  },
+  register: (username: string) => demoApi.login(username, "") as Promise<User>,
+
+  // --- account self-service ---
+  changeUsername: (username: string) => {
+    try {
+      localStorage.setItem(USERNAME_KEY, username);
+    } catch {
+      // ignore
+    }
+    return tick(demoUser());
+  },
+  unlinkOIDC: () => tick(demoUser()),
+
+  // --- reminders ---
+  getReminders: () => tick(DEMO_REMINDERS),
+  putReminders: (settings: ReminderSettings) => tick(settings),
+  testReminder: () => tick({ ok: true }),
+
+  wipeMyData: () => {
+    const db = loadDB();
+    const deletedTasks = db.tasks.length;
+    db.tasks = [];
+    db.completions = [];
+    saveDB(db);
+    return tick({ deletedTasks });
+  },
+
+  deleteAccount: () => {
+    setSession(false);
+    return tick(undefined);
+  },
+
+  changePassword: () => tick(undefined),
+
+  getPreferences: () => {
+    try {
+      const raw = localStorage.getItem(PREFS_KEY);
+      if (raw) return tick(JSON.parse(raw) as Record<string, unknown>);
+    } catch {
+      // ignore
+    }
+    return tick({});
+  },
+
+  putPreferences: (data: unknown) => {
+    try {
+      localStorage.setItem(PREFS_KEY, JSON.stringify(data));
+    } catch {
+      // ignore
+    }
+    return tick(undefined);
+  },
+
+  // --- admin (hidden in the demo: the account is a plain user) ---
+  listUsers: notAvailable,
+  adminCreateUser: notAvailable,
+  adminUpdateUser: notAvailable,
+  adminDeleteUser: notAvailable,
+  getSettings: notAvailable,
+  putSettings: notAvailable,
+  adminWipe: notAvailable,
+  listPending: notAvailable,
+  approveUser: notAvailable,
+  mergeUsers: notAvailable,
+  listSessions: notAvailable,
+  terminateSessions: notAvailable,
+  listLogs: notAvailable,
+  setDefaultTheme: () => tick(undefined),
+  createBackup: notAvailable,
+  listBackups: notAvailable,
+  backupURL: (name: string) => `#${name}`,
+  deleteBackup: notAvailable,
+  restoreBackup: notAvailable,
+  restoreUpload: notAvailable,
+};

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,6 +7,8 @@
 // place.
 
 import type { Theme } from "./theme";
+import { DEMO } from "./demo";
+import { demoApi } from "./api.demo";
 
 export interface Task {
   id: number;
@@ -188,7 +190,7 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
-export const api = {
+const httpApi = {
   listTasks: () => request<Task[]>("/api/tasks"),
 
   createTask: (input: TaskInput) =>
@@ -406,3 +408,13 @@ export const api = {
     return res.json();
   },
 };
+
+/**
+ * The shape every consumer talks to. The real client (`httpApi`) and the demo's
+ * in-browser mock (`demoApi`) both implement it, so swapping transport happens
+ * only here. `DEMO` is a compile-time literal, so a normal build inlines
+ * `httpApi` and tree-shakes the demo module out entirely.
+ */
+export type Api = typeof httpApi;
+
+export const api: Api = DEMO ? demoApi : httpApi;

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -1,0 +1,9 @@
+// Demo mode flag.
+//
+// `__DEMO__` is a compile-time boolean injected by Vite (see vite.config.ts):
+// true only for the static GitHub Pages build (`VITE_DEMO=1`), false otherwise.
+// Because it's a literal at build time, the bundler tree-shakes the demo data
+// layer out of normal (server-backed) builds entirely.
+declare const __DEMO__: boolean;
+
+export const DEMO: boolean = __DEMO__;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,14 +8,23 @@ const pkg = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
 ) as { version: string };
 
-// The build writes straight into the Go binary's embed directory so the
+// Demo mode (VITE_DEMO=1): a static, server-less build for GitHub Pages. The API
+// layer is swapped for an in-browser mock (see src/lib/api.demo.ts) and assets
+// are served from the project subpath (https://<user>.github.io/taskrr/).
+const demo = process.env.VITE_DEMO === "1";
+
+// The normal build writes straight into the Go binary's embed directory so the
 // frontend ships inside the single backend binary. During `npm run dev`, API
-// calls are proxied to the Go server on :8787.
+// calls are proxied to the Go server on :8787. The demo build instead emits to
+// web/dist-demo (it is never embedded in the binary).
 export default defineConfig({
+  base: demo ? "/taskrr/" : "/",
   plugins: [react()],
   define: {
     // Compile-time constant, referenced as __APP_VERSION__ in the app.
     __APP_VERSION__: JSON.stringify(pkg.version),
+    // True only in the GitHub Pages demo build; gates the in-browser mock API.
+    __DEMO__: JSON.stringify(demo),
   },
   resolve: {
     alias: {
@@ -23,7 +32,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: "../internal/web/dist",
+    outDir: demo ? "dist-demo" : "../internal/web/dist",
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
## Summary

This PR adds a fully functional, server-less demo of Taskrr that runs entirely in the browser and is deployed to GitHub Pages. The demo uses an in-browser mock of the API layer that persists data to localStorage, allowing visitors to try the app without any backend infrastructure.

## Key Changes

- **In-browser API mock** (`web/src/lib/api.demo.ts`): Implements the complete `Api` interface with localStorage-backed persistence. Includes realistic seed data with tasks, completions, and activity spanning ~30 days to make the demo feel alive.

- **Demo mode flag** (`web/src/lib/demo.ts`): Compile-time constant that enables tree-shaking of demo code from production builds.

- **API layer abstraction** (`web/src/lib/api.ts`): Refactored to export a type-safe `Api` interface and swap between `httpApi` (production) and `demoApi` (demo) at a single seam. The swap is compile-time, so normal builds include zero demo overhead.

- **Demo banner UI** (`web/src/components/DemoBanner.tsx`): Fixed notification shown only in demo mode that explains there's no server, data is browser-local, and provides a one-click reset button to clear localStorage and reload.

- **Build configuration** (`web/vite.config.ts`): Added `VITE_DEMO` environment variable support to build a separate static bundle with `/taskrr/` base path for GitHub Pages deployment.

- **CI/CD workflow** (`.github/workflows/demo.yml`): New GitHub Actions workflow that builds and deploys the demo to GitHub Pages on pushes to main or manual trigger.

- **Documentation** (`README.md`): Added "Live demo" section with link to the deployed demo.

## Implementation Details

- The demo seeds with 12 realistic tasks (watering plants, cleaning, backups, etc.) with completion histories relative to "now", so the calendar and activity views always look populated.
- All data (tasks, completions, preferences, session state) lives in localStorage under demo-specific keys, isolated from any real app data.
- The mock implements the exact same surface as the HTTP client, so every component, query, and mutation works unchanged.
- Admin features (users, sessions, logs, backups, OIDC, reminders) are stubbed to throw "Not available in the demo" errors, keeping the admin UI hidden.
- Small artificial latency (80ms) on all operations makes optimistic UI and loading states visible, mimicking real network behavior.
- The demo build outputs to `web/dist-demo/` and is never embedded in the binary.

https://claude.ai/code/session_01HGKWYtuVU8Z6LeXt5P9Hy1