### PR TITLE
Demo polish, system-following time prefs, slimmer config files (v1.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,73 +1,41 @@
-# Taskrr configuration — copy to `.env` and adjust. Docker Compose loads this
-# file automatically. Every value has a sensible default; uncomment to override.
+# Taskrr configuration — copy to `.env`. Every value has a sensible default;
+# uncomment to override.
 
-# --- server ---------------------------------------------------------------
-# Address the server listens on.
 #TASKRR_ADDR=:8787
-# Path to the SQLite database file (its directory is created automatically).
+
 #TASKRR_DB_PATH=./data/taskrr.db
 
-# --- bootstrap admin (Phase 2) --------------------------------------------
-# The first admin account is created on first boot. Provide EITHER a plaintext
-# password OR a pre-computed hash (the hash wins if both are set, so you can keep
-# secrets out of plaintext). Plaintext is simplest — the app hashes it on first
-# boot.
-#
-# To pre-hash, run ONE of these and paste the output below. NOTE: plain
-# `openssl passwd` does NOT work — it makes crypt-style hashes, not this PBKDF2
-# format. The commands emit the hash already DOUBLED ($$): a PBKDF2 hash contains
-# `$`, and Docker Compose treats `$` in this file as variable interpolation, so a
-# raw hash is silently corrupted (you'd see "variable is not set" warnings).
-# Compose collapses `$$` back to a single `$` for the container, and the app logs
-# a warning at startup if the configured hash looks malformed.
-# (Passing the hash via systemd / `docker run -e` instead? Use a single `$` —
-# drop the trailing `sed`, or undouble the python/openssl `$$`.)
-#
-#   # simplest, with Docker (build the image first):
-#   docker compose run --rm taskrr -hash-password 'your-password' | sed 's/[$]/$$/g'
-#
-#   # the binary:
-#   taskrr -hash-password 'your-password' | sed 's/[$]/$$/g'
-#
-#   # python3:
-#   python3 -c "import hashlib,os,base64,sys; s=os.urandom(16); k=hashlib.pbkdf2_hmac('sha256',sys.argv[1].encode(),s,600000,32); e=lambda x:base64.b64encode(x).decode().rstrip('='); print('pbkdf2-sha256\$\$600000\$\$'+e(s)+'\$\$'+e(k))" 'your-password'
-#
-#   # openssl only (bash; OpenSSL 3.x):
-#   PW='your-password'; S=$(openssl rand -hex 16); \
-#     K=$(openssl kdf -keylen 32 -kdfopt digest:SHA2-256 -kdfopt iter:600000 -kdfopt pass:"$PW" -kdfopt hexsalt:"$S" -binary PBKDF2 | base64 | tr -d '=\n'); \
-#     printf 'pbkdf2-sha256$$600000$$%s$$%s\n' "$(printf "$(echo "$S"|sed 's/../\\x&/g')" | base64 | tr -d '=\n')" "$K"
-#
-# Example of the escaped value: pbkdf2-sha256$$600000$$<salt>$$<hash>
+# Bootstrap admin, created on first start. Give EITHER a plaintext password OR
+# a pre-computed hash (hash wins). Leave both unset to choose the password in
+# the browser on the first sign-in.
 TASKRR_ADMIN_USERNAME=admin
-TASKRR_ADMIN_PASSWORD=change-me-please
-#TASKRR_ADMIN_PASSWORD_HASH=pbkdf2-sha256$$600000$$...$$...
+#TASKRR_ADMIN_PASSWORD=
+#TASKRR_ADMIN_PASSWORD_HASH=
 
-# How long a login session lasts (Go duration, e.g. 720h = 30 days). Sessions
-# slide: a visit past the halfway point extends them by a full TTL, so only an
-# account left unused for a whole TTL is signed out.
+# Generate a hash with either one-liner (output is already `$$`-escaped for
+# this file — Compose treats a single `$` as variable interpolation):
+#   docker compose run --rm taskrr -hash-password 'your-password' | sed 's/[$]/$$/g'
+#   PW='your-password'; S=$(openssl rand -hex 16); K=$(openssl kdf -keylen 32 -kdfopt digest:SHA2-256 -kdfopt iter:600000 -kdfopt pass:"$PW" -kdfopt hexsalt:"$S" -binary PBKDF2 | base64 | tr -d '=\n'); printf 'pbkdf2-sha256$$600000$$%s$$%s\n' "$(printf "$(echo "$S"|sed 's/../\\x&/g')" | base64 | tr -d '=\n')" "$K"
+
+# How long a sign-in lasts (Go duration). Sessions extend while in use.
 #TASKRR_SESSION_TTL=720h
-# Mark session cookies Secure (HTTPS-only). Enable when behind a TLS proxy.
+
+# Set true behind HTTPS.
 #TASKRR_COOKIE_SECURE=false
-# Trust CF-Connecting-IP / X-Forwarded-For for the client IP (used by per-IP
-# login rate limiting and access logs). Keep true behind a reverse proxy
-# (Cloudflare, Caddy, nginx). Set false if Taskrr is reachable directly —
-# otherwise those headers can be spoofed to dodge the per-IP limiter.
+
+# Read the client IP from reverse-proxy headers (rate limiting, logs).
+# Set false if Taskrr is exposed directly, so the headers can't be spoofed.
 #TASKRR_TRUST_PROXY_HEADERS=true
 
-# How often the reminder loop checks for due tasks to send webhook reminders
-# (Go duration). Each user opts in and sets their own webhook in Settings.
-#TASKRR_REMINDER_INTERVAL=1m
-
-# Lite mode: single-person instance. Disables self-registration and creating
-# extra accounts (and hides those bits of the UI). The bootstrap admin still works.
+# Single-person mode: disables registration and extra accounts.
 #TASKRR_LITE=false
 
-# --- OIDC / Authentik (Phase 2; can also be set later in the admin UI) -----
-# Leave blank to disable OIDC. The issuer is your Authentik application's
-# OpenID configuration URL (without the /.well-known/... suffix).
+# How often the reminder loop checks for due tasks.
+#TASKRR_REMINDER_INTERVAL=1m
+
+# OIDC single sign-on — also configurable later in the admin UI.
+# A secret containing `$` needs each one doubled to `$$` here.
 #TASKRR_OIDC_ISSUER=https://auth.example.com/application/o/taskrr/
 #TASKRR_OIDC_CLIENT_ID=
-# If the client secret contains a `$`, double each to `$$` here (same Compose
-# interpolation caveat as the password hash above).
 #TASKRR_OIDC_CLIENT_SECRET=
-#TASKRR_OIDC_REDIRECT_URL=https://taskrr.example.com/api/auth/oidc/callback
+#TASKRR_OIDC_REDIRECT_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,3 @@
-# Taskrr — a self-hosted tracker for when you last did things.
-#
-# This file is all you need to run it:
-#
-#   mkdir taskrr && cd taskrr
-#   curl -LO https://raw.githubusercontent.com/unmaykr-a/taskrr/main/docker-compose.yml
-#   mkdir data
-#   docker compose up -d
-#
-# Then open http://localhost:8787 and sign in as "admin" — you'll be asked to
-# set a password on the first sign-in.
-#
-# Your data is the plain ./data folder next to this file; backing up or moving
-# the instance is copying that folder. (Create it yourself, as above — if
-# Docker creates it, it's owned by root and the app can't write to it.) The
-# container writes as uid/gid 1000 by default; if `id -u` says otherwise, set
-# TASKRR_UID / TASKRR_GID.
-#
-# Optional: put settings in a .env file next to this one (see .env.example in
-# the repo) to preset the admin password, configure OIDC, enable lite mode, etc.
-
 services:
   taskrr:
     image: ghcr.io/unmaykr-a/taskrr:latest
@@ -35,7 +14,6 @@ services:
       TASKRR_DB_PATH: "/data/taskrr.db"
     volumes:
       - ./data:/data
-    # The image is distroless (no shell), so the binary probes itself.
     healthcheck:
       test: ["CMD", "/taskrr", "-health"]
       interval: 60s

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/Calendar.tsx
+++ b/web/src/components/Calendar.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { api, type Activity, type Task } from "@/lib/api";
-import { formatDue } from "@/lib/time";
+import { formatDue, formatTime } from "@/lib/time";
 import { nextDue } from "@/lib/staleness";
 import { usePrefs } from "@/lib/prefs";
 import { cn } from "@/lib/utils";
@@ -400,10 +400,7 @@ export function Calendar({
                 <div className="flex items-center gap-2">
                   <span className="font-medium">{a.taskName}</span>
                   <span className="text-muted-foreground">
-                    {new Date(a.completedAt).toLocaleTimeString(undefined, {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
+                    {formatTime(new Date(a.completedAt))}
                   </span>
                 </div>
                 {a.note && (

--- a/web/src/components/DateTimePicker.tsx
+++ b/web/src/components/DateTimePicker.tsx
@@ -3,10 +3,9 @@ import { useState } from "react";
 import { usePrefs } from "@/lib/prefs";
 import { ClockPicker } from "@/components/ClockPicker";
 
-// A date + analog-clock time picker that we fully control, so:
-//   - the time is chosen from a familiar clock face (not fiddly dropdowns), and
-//   - the user can flip between 12- and 24-hour display (defaulting to their
-//     locale), which the native <input type="time"> doesn't allow.
+// A date + analog-clock time picker that we fully control, so the time is
+// chosen from a familiar clock face (not fiddly dropdowns). 12- vs 24-hour
+// display follows the Preferences -> Time & date setting (system by default).
 //
 // `value` is a Date (local time); `onChange` reports a new Date. Seconds are
 // zeroed so logged times are clean.
@@ -26,7 +25,7 @@ export function DateTimePicker({
   onChange: (next: Date) => void;
   max?: Date;
 }) {
-  const { prefs, setPrefs } = usePrefs();
+  const { prefs } = usePrefs();
   const hour12 = prefs.hour12;
   const [showClock, setShowClock] = useState(false);
 
@@ -73,14 +72,6 @@ export function DateTimePicker({
           aria-expanded={showClock}
         >
           {timeLabel}
-        </button>
-        <button
-          type="button"
-          onClick={() => setPrefs({ hour12: !hour12 })}
-          className="ml-auto rounded-md border border-input px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          title="Switch between 12- and 24-hour time"
-        >
-          {hour12 ? "12h" : "24h"}
         </button>
       </div>
 

--- a/web/src/components/DemoBanner.tsx
+++ b/web/src/components/DemoBanner.tsx
@@ -3,6 +3,7 @@ import { Github, Info, RotateCcw, X } from "lucide-react";
 
 import { DEMO } from "@/lib/demo";
 import { DEMO_KEYS } from "@/lib/api.demo";
+import { clearStoredPreferences } from "@/lib/prefs";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -23,14 +24,20 @@ export function DemoBanner() {
     } catch {
       // storage unavailable — nothing to clear
     }
+    // Also wipe the theme and UI preferences (taskrr-* keys), so reset really
+    // means "back to the first visit" — not just the seed tasks.
+    clearStoredPreferences();
     window.location.reload();
   };
 
   return (
     <div
+      // Bottom-centre: clear of the sidebar's account/settings corner and the
+      // calendar/activity column. slide-in-from-left-1/2 keeps the enter
+      // keyframe's x at -50% so the rise doesn't fight the centering.
       className={cn(
-        "fixed bottom-4 left-4 z-[60] max-w-[calc(100vw-2rem)] rounded-xl border bg-card/95 p-3 shadow-2xl backdrop-blur",
-        "animate-in fade-in-0 slide-in-from-bottom-2 duration-300",
+        "fixed bottom-4 left-1/2 z-[60] max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border bg-card/95 p-3 shadow-2xl backdrop-blur",
+        "animate-in fade-in-0 slide-in-from-left-1/2 slide-in-from-bottom-2 duration-300",
       )}
     >
       <div className="flex items-start gap-2.5">

--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -36,7 +36,7 @@ export function SettingsPanel({ initial = "account" }: { initial?: Section }) {
           so this frees the whole width for content). Desktop: a vertical side nav. */}
       <nav
         ref={navRef}
-        className="relative flex shrink-0 gap-1 overflow-x-auto border-b pb-2 sm:sticky sm:top-0 sm:w-32 sm:flex-col sm:self-start sm:overflow-visible sm:border-b-0 sm:pb-0"
+        className="relative flex shrink-0 gap-1 overflow-x-auto border-b pb-2 sm:sticky sm:top-0 sm:w-36 sm:flex-col sm:self-start sm:overflow-visible sm:border-b-0 sm:pb-0"
       >
         {/* The active background is a bubble that slides between nav items
             (works in both the phone row and desktop column orientation). */}

--- a/web/src/components/settings/PreferencesSection.tsx
+++ b/web/src/components/settings/PreferencesSection.tsx
@@ -1,9 +1,12 @@
 import {
   type AddButtonPosition,
   type CardSize,
+  type ClockChoice,
   type ColorPickerStyle,
+  type DateOrder,
   usePrefs,
 } from "@/lib/prefs";
+import { Segmented } from "@/components/ui/Segmented";
 import { ColorField } from "@/components/ui/ColorPicker";
 import { Label } from "@/components/ui/label";
 
@@ -17,20 +20,37 @@ export function PreferencesSection() {
 
   return (
     <div className="space-y-5">
-      {/* Clock */}
+      {/* Time & date */}
       <section className="space-y-2">
-        <h3 className="text-sm font-semibold">Time</h3>
+        <h3 className="text-sm font-semibold">Time &amp; date</h3>
         <div className="space-y-1">
           <Label className="text-xs text-muted-foreground">Clock</Label>
-          <select
-            className={SELECT}
-            value={prefs.hour12 ? "12" : "24"}
-            onChange={(e) => setPrefs({ hour12: e.target.value === "12" })}
-          >
-            <option value="12" className="bg-background">12-hour (AM/PM)</option>
-            <option value="24" className="bg-background">24-hour</option>
-          </select>
+          <Segmented
+            value={prefs.clock}
+            onChange={(v: ClockChoice) => setPrefs({ clock: v })}
+            options={[
+              { value: "auto", label: "Auto", title: "Follow this device's system setting" },
+              { value: "12", label: "12-hour" },
+              { value: "24", label: "24-hour" },
+            ]}
+          />
         </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Date format</Label>
+          <Segmented
+            value={prefs.dateFormat}
+            onChange={(v: DateOrder) => setPrefs({ dateFormat: v })}
+            options={[
+              { value: "auto", label: "Auto", title: "Follow this device's system setting" },
+              { value: "dmy", label: "13 Jun" },
+              { value: "mdy", label: "Jun 13" },
+              { value: "ymd", label: "2026-06-13" },
+            ]}
+          />
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Auto follows each device's own system settings.
+        </p>
       </section>
 
       {/* Task staleness colours + gradient */}

--- a/web/src/components/ui/Segmented.tsx
+++ b/web/src/components/ui/Segmented.tsx
@@ -1,0 +1,49 @@
+import { useRef } from "react";
+
+import { cn } from "@/lib/utils";
+import { SlidingHighlight } from "@/components/ui/SlidingHighlight";
+
+/**
+ * Segmented is a small multi-option toggle where the filled pill glides to the
+ * selected option (same sliding-bubble treatment as the sidebar views and the
+ * login tabs). Use it for 2-4 short, mutually exclusive choices.
+ */
+export function Segmented<T extends string>({
+  value,
+  options,
+  onChange,
+  className,
+}: {
+  value: T;
+  options: { value: T; label: string; title?: string }[];
+  onChange: (value: T) => void;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "relative grid auto-cols-fr grid-flow-col gap-1 rounded-lg border bg-muted/40 p-1 text-xs",
+        className,
+      )}
+    >
+      <SlidingHighlight containerRef={ref} activeKey={value} className="rounded-md bg-primary" />
+      {options.map((o) => (
+        <button
+          key={o.value}
+          data-slide-key={o.value}
+          type="button"
+          title={o.title}
+          onClick={() => onChange(o.value)}
+          className={cn(
+            "relative rounded-md px-2 py-1.5 transition-colors duration-200",
+            value === o.value ? "font-medium text-primary-foreground" : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/lib/prefs.tsx
+++ b/web/src/lib/prefs.tsx
@@ -17,13 +17,23 @@ import {
 } from "react";
 
 import { installSmoothWheel } from "@/lib/smoothScroll";
+import { setTimeFormat } from "@/lib/time";
 
 export type ColorPickerStyle = "wheel" | "native";
 export type AddButtonPosition = "top" | "bottom";
 export type CardSize = "comfortable" | "compact";
+export type ClockChoice = "auto" | "12" | "24";
+export type DateOrder = "auto" | "dmy" | "mdy" | "ymd";
 
 export interface Prefs {
-  /** 12- vs 24-hour time display. */
+  /** Clock display: follow the device's system setting, or force 12/24-hour.
+   *  "auto" is what gets stored, so the same account follows each device's
+   *  own convention instead of freezing whichever locale saved first. */
+  clock: ClockChoice;
+  /** Date display for absolute timestamps: system, day-first, month-first, ISO. */
+  dateFormat: DateOrder;
+  /** Resolved 12- vs 24-hour flag, derived from `clock` by the provider each
+   *  render — components read this; only `clock` is the stored setting. */
   hour12: boolean;
   /** Default colours for the two ends of the task staleness gradient. */
   taskColorFresh: string;
@@ -97,7 +107,9 @@ export function localeHour12(): boolean {
 
 function defaults(): Prefs {
   return {
-    hour12: localeHour12(),
+    clock: "auto",
+    dateFormat: "auto",
+    hour12: localeHour12(), // derived; recomputed from `clock` by the provider
     taskColorFresh: "#22c55e", // emerald
     taskColorOverdue: "#ef4444", // red
     noRoutineFadeDays: 7,
@@ -131,12 +143,18 @@ function load(): Prefs {
     if (raw) return { ...base, ...(JSON.parse(raw) as Partial<Prefs>) };
     // Migrate the old standalone 12/24h key if present.
     const legacy = localStorage.getItem(LEGACY_HOUR12);
-    if (legacy === "12") return { ...base, hour12: true };
-    if (legacy === "24") return { ...base, hour12: false };
+    if (legacy === "12") return { ...base, clock: "12" };
+    if (legacy === "24") return { ...base, clock: "24" };
   } catch {
     // ignore and use defaults
   }
   return base;
+}
+
+/** Resolve the stored clock choice into the 12/24 flag components consume. */
+function resolveHour12(clock: ClockChoice): boolean {
+  if (clock === "auto") return localeHour12();
+  return clock === "12";
 }
 
 const Ctx = createContext<{ prefs: Prefs; setPrefs: (p: Partial<Prefs>) => void } | null>(null);
@@ -167,7 +185,14 @@ export function PrefsProvider({ children }: { children: ReactNode }) {
   }, [prefs.smoothScroll]);
 
   const setPrefs = useCallback((p: Partial<Prefs>) => setState((cur) => ({ ...cur, ...p })), []);
-  const value = useMemo(() => ({ prefs, setPrefs }), [prefs, setPrefs]);
+  const value = useMemo(() => {
+    const hour12 = resolveHour12(prefs.clock);
+    // Push the format choices into the pure time helpers *during* render, so
+    // formatDateTime/formatTime read the new format on the same pass the
+    // consumers re-render (an effect would lag one frame behind).
+    setTimeFormat({ dateOrder: prefs.dateFormat, hour12: prefs.clock === "auto" ? undefined : hour12 });
+    return { prefs: { ...prefs, hour12 }, setPrefs };
+  }, [prefs, setPrefs]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }

--- a/web/src/lib/time.ts
+++ b/web/src/lib/time.ts
@@ -36,12 +36,51 @@ export function daysSince(iso: string | null): number | null {
   return (Date.now() - new Date(iso).getTime()) / 86_400_000;
 }
 
-/** formatDateTime renders an absolute, locale-aware date and time. */
-export function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
+// --- absolute date/time formatting -------------------------------------------
+// The Preferences "Time & date" section can override the system defaults; the
+// PrefsProvider pushes its choices in here so every caller picks the format up
+// automatically.
+
+export type DateOrder = "auto" | "dmy" | "mdy" | "ymd";
+
+let dateOrder: DateOrder = "auto";
+let hour12Override: boolean | undefined; // undefined = follow the locale
+
+/** setTimeFormat applies the user's date/clock preferences (see PrefsProvider). */
+export function setTimeFormat(opts: { dateOrder: DateOrder; hour12?: boolean }) {
+  dateOrder = opts.dateOrder;
+  hour12Override = opts.hour12;
+}
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/** formatTime renders just the clock time, honouring the 12/24h preference. */
+export function formatTime(d: Date): string {
+  return d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    ...(hour12Override !== undefined ? { hour12: hour12Override } : {}),
   });
+}
+
+/** formatDate renders just the date, honouring the date-order preference. */
+export function formatDate(d: Date): string {
+  switch (dateOrder) {
+    case "dmy":
+      return d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+    case "mdy":
+      return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    case "ymd":
+      return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+    default:
+      return d.toLocaleDateString(undefined, { dateStyle: "medium" });
+  }
+}
+
+/** formatDateTime renders an absolute date and time per the user's preferences. */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return `${formatDate(d)}, ${formatTime(d)}`;
 }
 
 /**


### PR DESCRIPTION
The full feedback batch on the live demo plus the config-file slimming. Typecheck, tests, and both the normal and demo builds pass; the demo redeploys automatically on merge.

## Demo fixes

- **Banner moved to the bottom centre** — it sat bottom-left covering the sidebar's account/settings corner. Centre is clear of both the sidebar and the calendar/activity column (and it remains dismissible).
- **Reset demo now resets everything**: it previously cleared only the demo's own data keys, so the theme and UI preferences survived. It now also wipes all `taskrr-*` keys (theme included) before reloading — reset means "back to the first visit".

## Time & date follow the system properly

The root cause of "time settings don't follow the system": the 12/24h flag was resolved from the locale once and then *persisted*, so whichever device saved first froze the choice for the account. Restructured:

- The stored preference is now **Clock: Auto / 12-hour / 24-hour**, default Auto — Auto re-resolves from each device's own system setting at read time. Existing users move to Auto.
- A new **Date format: Auto / 13 Jun / Jun 13 / 2026-06-13** preference joins it in a "Time & date" section; all absolute timestamps (task cards, history, calendar day detail) honour both.
- Both render as **animated sliding-bubble toggles** (new reusable `ui/Segmented.tsx`, same treatment as the sidebar/login tabs).
- The **redundant 12h/24h flip button is removed** from the advanced-log and edit-entry pickers — the pickers just follow the preference.
- The settings side nav is widened (`w-32` -> `w-36`) so "Preferences" no longer truncates.

## Slim config files

- **docker-compose.yml**: the entire comment header is gone — it's now just the service definition (the README carries the quick start).
- **.env.example**: rewritten clean — self-explanatory entries lost their comments, every entry is separated by a blank line, and the password-hash guides are down to exactly two copy-paste **one-liners** (the `docker compose run ... | sed` one and the openssl one, no multi-line continuation to trim).

Version 1.2.0.

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_