### PR TITLE
Safety-backup toggle, section arrows, Advanced rename, versioned GHCR images (v1.5.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ TASKRR_ADMIN_USERNAME=admin
 # How often the reminder loop checks for due tasks.
 #TASKRR_REMINDER_INTERVAL=1m
 
+# Take an automatic backup of the database right before a restore, so a
+# mistaken restore can be undone. Off stops the backups folder filling with a
+# safety snapshot on every restore.
+#TASKRR_SAFETY_BACKUP=true
+
 # OIDC single sign-on — also configurable later in the admin UI.
 # A secret containing `$` needs each one doubled to `$$` here.
 #TASKRR_OIDC_ISSUER=https://auth.example.com/application/o/taskrr/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 # Builds and publishes the multi-arch Docker image to GHCR, so users can run
 # Taskrr straight from the compose file with no cloning or building:
-#   - every push to main updates ghcr.io/<owner>/taskrr:latest
-#   - a v* tag additionally publishes the version tag (e.g. 1.0.0)
+#   - every push to main publishes ghcr.io/<owner>/taskrr:latest AND a tag for
+#     the current version from web/package.json (e.g. :1.5.0), so every released
+#     version stays pullable on the Packages page
+#   - a v* git tag also publishes its semver tag
 name: Release
 
 on:
@@ -27,12 +29,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The app version is the single source of truth in web/package.json; tag
+      # each main build with it so every version stays available in GHCR.
+      - id: ver
+        run: echo "version=$(node -p "require('./web/package.json').version")" >> "$GITHUB_OUTPUT"
       - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.ver.outputs.version }},enable={{is_default_branch}}
             type=semver,pattern={{version}}
       - uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ working examples. The short version:
 | `TASKRR_SECRET_KEY` | — | Encrypt the OIDC client secret at rest, so it isn't stored — or backed up — in plaintext |
 | `TASKRR_LITE` | `false` | Single-person mode: disables registration and extra accounts |
 | `TASKRR_REMINDER_INTERVAL` | `1m` | How often the reminder loop checks for due tasks |
+| `TASKRR_SAFETY_BACKUP` | `true` | Snapshot the DB before a restore (so a mistaken restore is undoable); set `false` to skip it |
 | `TASKRR_OIDC_*` | — | Issuer, client id/secret, redirect URL — also editable later in the admin UI |
 
 Running behind a reverse proxy with HTTPS is the intended setup for anything

--- a/cmd/taskrr/main.go
+++ b/cmd/taskrr/main.go
@@ -92,14 +92,15 @@ func main() {
 	srv := &http.Server{
 		Addr: cfg.Addr,
 		Handler: api.NewServer(st, api.Options{
-			SessionTTL:        cfg.SessionTTL,
-			CookieSecure:      cfg.CookieSecure,
-			ProtectedUserID:   adminID,
-			OnRestart:         requestRestart,
-			Logs:              logs,
-			Lite:              cfg.Lite,
-			TrustProxyHeaders: cfg.TrustProxyHeaders,
-			Secrets:           secrets,
+			SessionTTL:            cfg.SessionTTL,
+			CookieSecure:          cfg.CookieSecure,
+			ProtectedUserID:       adminID,
+			OnRestart:             requestRestart,
+			Logs:                  logs,
+			Lite:                  cfg.Lite,
+			TrustProxyHeaders:     cfg.TrustProxyHeaders,
+			Secrets:               secrets,
+			SafetyBackupOnRestore: cfg.SafetyBackupOnRestore,
 		}).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1196,11 +1196,17 @@ func (s *Server) handleRestoreUpload(w http.ResponseWriter, r *http.Request) {
 // actual file swap happens on the next startup (applyPendingRestore), which is
 // the only safe moment to replace an open SQLite file.
 func (s *Server) doRestore(w http.ResponseWriter, r *http.Request, stage func() error) {
-	safety, err := s.store.Backup(r.Context())
-	if err != nil {
-		log.Printf("restore: safety backup failed: %v", err)
-		writeError(w, http.StatusInternalServerError, "could not take a safety backup before restoring")
-		return
+	// Take a safety snapshot of the current DB first, unless disabled
+	// (TASKRR_SAFETY_BACKUP=false), so a mistaken restore can be undone.
+	var safety string
+	if s.opts.SafetyBackupOnRestore {
+		var err error
+		safety, err = s.store.Backup(r.Context())
+		if err != nil {
+			log.Printf("restore: safety backup failed: %v", err)
+			writeError(w, http.StatusInternalServerError, "could not take a safety backup before restoring")
+			return
+		}
 	}
 	if err := stage(); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -1211,7 +1217,11 @@ func (s *Server) doRestore(w http.ResponseWriter, r *http.Request, stage func() 
 		return
 	}
 	s.restoring.Store(true) // block new logins during the brief pre-restart window
-	log.Printf("restore: staged; restarting (safety backup: %s)", safety)
+	if safety != "" {
+		log.Printf("restore: staged; restarting (safety backup: %s)", safety)
+	} else {
+		log.Printf("restore: staged; restarting (no safety backup — TASKRR_SAFETY_BACKUP is off)")
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "restarting": true, "safetyBackup": safety})
 
 	if s.opts.OnRestart != nil {

--- a/internal/api/safety_backup_test.go
+++ b/internal/api/safety_backup_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSafetyBackupToggle verifies the pre-restore safety backup honours the
+// SafetyBackupOnRestore option: a snapshot is taken when on, and skipped when off.
+func TestSafetyBackupToggle(t *testing.T) {
+	t.Run("on", func(t *testing.T) {
+		st := openStore(t)
+		s := NewServer(st, Options{SafetyBackupOnRestore: true})
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/api/admin/restore/x", nil)
+		s.doRestore(w, r, func() error { return nil }) // stage is a no-op
+		if w.Code != 200 {
+			t.Fatalf("doRestore = %d, want 200 (%s)", w.Code, w.Body.String())
+		}
+		backups, err := st.ListBackups()
+		if err != nil {
+			t.Fatalf("ListBackups: %v", err)
+		}
+		if len(backups) != 1 {
+			t.Fatalf("safety backup on: want 1 backup, got %d", len(backups))
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		st := openStore(t)
+		s := NewServer(st, Options{SafetyBackupOnRestore: false})
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/api/admin/restore/x", nil)
+		s.doRestore(w, r, func() error { return nil })
+		if w.Code != 200 {
+			t.Fatalf("doRestore = %d, want 200 (%s)", w.Code, w.Body.String())
+		}
+		backups, err := st.ListBackups()
+		if err != nil {
+			t.Fatalf("ListBackups: %v", err)
+		}
+		if len(backups) != 0 {
+			t.Fatalf("safety backup off: want 0 backups, got %d", len(backups))
+		}
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -112,6 +112,9 @@ type Options struct {
 	// Secrets encrypts at-rest secrets (the OIDC client secret). A nil/no-op
 	// cipher keeps the legacy plaintext behaviour.
 	Secrets *auth.SecretCipher
+	// SafetyBackupOnRestore takes a backup of the current DB before a restore
+	// swaps it out (so a mistaken restore is recoverable). Default on.
+	SafetyBackupOnRestore bool
 }
 
 // Server holds the dependencies shared by all HTTP handlers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,12 @@ type Config struct {
 	// accounts) for a single-person instance. The one bootstrap admin still works.
 	Lite bool
 
+	// SafetyBackupOnRestore takes an automatic backup of the current database
+	// just before a restore swaps it out, so a mistaken restore can be undone.
+	// On by default; turn it off to stop the backups folder accumulating
+	// safety snapshots on every restore.
+	SafetyBackupOnRestore bool
+
 	// --- OIDC (Phase 2; initial values, overridable later in the admin UI) ---
 	OIDCIssuer       string
 	OIDCClientID     string
@@ -85,6 +91,8 @@ func Load() Config {
 		SecretKey:         env("TASKRR_SECRET_KEY", ""),
 		ReminderInterval:  envDuration("TASKRR_REMINDER_INTERVAL", time.Minute),
 		Lite:              envBool("TASKRR_LITE", false),
+
+		SafetyBackupOnRestore: envBool("TASKRR_SAFETY_BACKUP", true),
 
 		OIDCIssuer:       env("TASKRR_OIDC_ISSUER", ""),
 		OIDCClientID:     env("TASKRR_OIDC_CLIENT_ID", ""),

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Trash2, UserPlus, X } from "lucide-react";
+import { ChevronRight, Trash2, UserPlus, X } from "lucide-react";
 
 import { api, type SettingsPatch, type User } from "@/lib/api";
 import { clearStoredPreferences } from "@/lib/prefs";
@@ -669,9 +669,12 @@ function OIDCSettings() {
   );
 
   return (
-    <details className="rounded-lg border">
-      <summary className="flex cursor-pointer select-none items-center justify-between px-3 py-2 text-sm font-semibold">
-        Single sign-on (OIDC)
+    <details className="group rounded-lg border">
+      <summary className="flex cursor-pointer select-none items-center justify-between gap-2 px-3 py-2 text-sm font-semibold list-none [&::-webkit-details-marker]:hidden">
+        <span className="flex items-center gap-1.5">
+          <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-90" />
+          Single sign-on (OIDC)
+        </span>
         <span className={data?.oidc_enabled ? "text-xs font-normal text-emerald-400" : "text-xs font-normal text-muted-foreground"}>
           {data?.oidc_enabled ? "enabled" : "not configured"}
         </span>

--- a/web/src/components/settings/AccountSection.tsx
+++ b/web/src/components/settings/AccountSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, KeyRound, Link2, Link2Off, Trash2, UserRound } from "lucide-react";
+import { AlertTriangle, ChevronRight, KeyRound, Link2, Link2Off, Trash2, UserRound } from "lucide-react";
 
 import { api } from "@/lib/api";
 import { clearStoredPreferences } from "@/lib/prefs";
@@ -216,13 +216,18 @@ export function AccountSection() {
 
       <RemindersSection />
 
-      {/* Danger zone: irreversible self-service actions, each gated by re-typing
-          the account's own username. Collapsed by default so it's tucked away. */}
-      <details className="rounded-md border border-destructive/40 bg-destructive/5">
-        <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-2 text-xs font-semibold text-destructive">
-          <AlertTriangle className="h-3.5 w-3.5" /> Danger zone
+      {/* Advanced: the irreversible self-service actions live here (each gated by
+          re-typing the account's own username), under a "Danger zone" label.
+          Collapsed by default so it's tucked away. */}
+      <details className="group rounded-md border">
+        <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-2 text-sm font-semibold list-none [&::-webkit-details-marker]:hidden">
+          <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-90" />
+          Advanced
         </summary>
-        <div className="space-y-3 border-t border-destructive/20 p-3">
+        <div className="space-y-3 border-t p-3">
+        <div className="flex items-center gap-1.5 text-xs font-semibold text-destructive">
+          <AlertTriangle className="h-3.5 w-3.5" /> Danger zone
+        </div>
         <div className="space-y-2">
           <p className="text-xs text-muted-foreground">
             Delete all your tasks and their history. Your account and settings stay.
@@ -250,11 +255,11 @@ export function AccountSection() {
         </div>
 
         {user?.protected ? (
-          <p className="border-t border-destructive/20 pt-3 text-xs text-muted-foreground">
+          <p className="border-t pt-3 text-xs text-muted-foreground">
             This is the primary admin account and can't be deleted.
           </p>
         ) : (
-          <div className="space-y-2 border-t border-destructive/20 pt-3">
+          <div className="space-y-2 border-t pt-3">
             <p className="text-xs text-muted-foreground">
               Permanently delete your account and everything in it. You'll be signed
               out immediately. This can't be undone.

--- a/web/src/components/settings/RemindersSection.tsx
+++ b/web/src/components/settings/RemindersSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Bell } from "lucide-react";
+import { Bell, ChevronRight } from "lucide-react";
 
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -53,8 +53,9 @@ export function RemindersSection() {
   const canSave = !enabled || webhookUrl.trim() !== "";
 
   return (
-    <details className="rounded-lg border">
-      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-2 text-sm font-semibold">
+    <details className="group rounded-lg border">
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-2 text-sm font-semibold list-none [&::-webkit-details-marker]:hidden">
+        <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-90" />
         <Bell className="h-3.5 w-3.5" /> Reminders
       </summary>
       <div className="space-y-2 border-t p-3">


### PR DESCRIPTION
Four items from the latest round.

## Safety backup is now an env toggle (`TASKRR_SAFETY_BACKUP`, default on)

The automatic snapshot taken right before a restore — the source of those extra backups you spotted — can now be turned off. Default is on (unchanged behaviour); set `TASKRR_SAFETY_BACKUP=false` and restores skip it, so the backups folder stops collecting a safety copy each time. The restart log line notes when it's skipped. Covered by `TestSafetyBackupToggle` (one backup created when on, none when off).

## Disclosure arrows on the three sections that lacked them

SSO, Reminders, and Account all use `display:flex` on their `<summary>`, which suppresses the browser's native disclosure triangle — that's why they had no arrow while Logs/Sessions/Advanced did. Each now shows an explicit chevron that rotates 90° when open (via Tailwind `group-open`), so they clearly read as openable. Verified in a headless demo capture: the Reminders arrow and the rotated Advanced arrow both render.

## Account "Danger zone" → "Advanced"

The Account collapsible is renamed **Advanced** and is now a neutral bordered section (no longer alarm-red on the outside). The **Danger zone** wording moves inside as a red heading above the wipe-tasks / delete-account actions, exactly as requested.

## Versioned images on the Packages page

`release.yml` now reads the version from `web/package.json` and tags every push to main with it (e.g. `ghcr.io/unmaykr-a/taskrr:1.5.0`) alongside `:latest`. So each released version stays pullable indefinitely — someone who wants to pin or roll back can use the exact number — without you needing to push git tags. (The `v*` git-tag path still works too.)

Version 1.5.0. Go vet + full suite, frontend typecheck/test/build all pass.

One operational note: this only starts producing versioned tags from the next merge onward — earlier versions (1.0–1.4) were only ever pushed as `:latest`, so they won't retroactively appear. From 1.5.0 on, every version is preserved.

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_