### PR TITLE
Colour-fade toggle, custom date picker + picker prefs, pop-out logs (v1.7.0)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronRight, Trash2, UserPlus, X } from "lucide-react";
+import { ChevronRight, ExternalLink, Trash2, UserPlus, X } from "lucide-react";
 
 import { api, type SettingsPatch, type User } from "@/lib/api";
 import { clearStoredPreferences } from "@/lib/prefs";
 import { timeSince } from "@/lib/time";
+import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/AuthProvider";
+import { useWindows } from "@/components/windows/WindowManager";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -43,24 +45,59 @@ export function AdminPanel() {
   );
 }
 
-/** Logs: a live tail of the in-memory server/access log ring, in a collapsible
- *  section (like Advanced). Polls only while expanded and "Live" is on, and
- *  auto-scrolls to the newest line. */
-function LogsSection() {
-  const [open, setOpen] = useState(false);
+/** LogsView is the live log tail itself: polls while mounted (with a Live
+ *  toggle) and auto-scrolls. Used inline in the collapsible section and as the
+ *  body of the popped-out window. `fill` makes the log box grow to its
+ *  container (the window); otherwise it's a fixed height. */
+function LogsView({ fill = false }: { fill?: boolean }) {
   const [live, setLive] = useState(true);
   const { data: logs } = useQuery({
     queryKey: ["logs"],
     queryFn: () => api.listLogs(0),
-    enabled: open, // don't fetch/poll while collapsed
-    refetchInterval: open && live ? 4000 : false,
+    refetchInterval: live ? 4000 : false,
   });
   const boxRef = useRef<HTMLDivElement>(null);
-
-  // Keep the view pinned to the newest line while tailing.
   useEffect(() => {
-    if (open && live && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight;
-  }, [logs, live, open]);
+    if (live && boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight;
+  }, [logs, live]);
+
+  return (
+    <div className={cn("space-y-2", fill && "flex h-full flex-col")}>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[11px] text-muted-foreground">
+          Recent server and access logs, kept in memory since the last restart.
+        </p>
+        <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+          <input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} />
+          Live
+        </label>
+      </div>
+      <div
+        ref={boxRef}
+        className={cn(
+          "overflow-auto rounded-md border bg-background/60 p-2 font-mono text-[11px] leading-relaxed",
+          fill ? "min-h-0 flex-1" : "h-64",
+        )}
+      >
+        {logs?.length === 0 && <p className="text-muted-foreground">No log lines yet.</p>}
+        {logs?.map((e) => (
+          <div key={e.seq} className="whitespace-pre-wrap break-all text-muted-foreground">
+            {e.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Logs: a collapsible live tail (polls only while expanded), plus a "Pop out"
+ *  button that opens the same view as a floating window — so logs can stay open
+ *  while other settings windows are used to test changes. */
+function LogsSection() {
+  const [open, setOpen] = useState(false);
+  const windows = useWindows();
+  const popOut = () =>
+    windows.open({ id: "logs", title: "Logs", width: 560, content: <LogsView fill /> });
 
   return (
     <details
@@ -69,26 +106,17 @@ function LogsSection() {
     >
       <summary className="cursor-pointer select-none px-3 py-2 text-sm font-semibold">Logs</summary>
       <div className="space-y-2 border-t p-3">
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-[11px] text-muted-foreground">
-            Recent server and access logs, kept in memory since the last restart.
-          </p>
-          <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
-            <input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} />
-            Live
-          </label>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={popOut}
+            title="Open logs in a floating window"
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink className="h-3.5 w-3.5" /> Pop out
+          </button>
         </div>
-        <div
-          ref={boxRef}
-          className="h-64 overflow-auto rounded-md border bg-background/60 p-2 font-mono text-[11px] leading-relaxed"
-        >
-          {logs?.length === 0 && <p className="text-muted-foreground">No log lines yet.</p>}
-          {logs?.map((e) => (
-            <div key={e.seq} className="whitespace-pre-wrap break-all text-muted-foreground">
-              {e.text}
-            </div>
-          ))}
-        </div>
+        {open && <LogsView />}
       </div>
     </details>
   );

--- a/web/src/components/DateTimePicker.tsx
+++ b/web/src/components/DateTimePicker.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 
 import { usePrefs } from "@/lib/prefs";
 import { ClockPicker } from "@/components/ClockPicker";
+import { DatePickerCalendar } from "@/components/ui/DatePickerCalendar";
 
-// A date + analog-clock time picker that we fully control, so the time is
-// chosen from a familiar clock face (not fiddly dropdowns). 12- vs 24-hour
-// display follows the Preferences -> Time & date setting (system by default).
+// Date + time picker. By default both halves use Taskrr's own controls — a
+// calendar for the date and an analog clock for the time — but each can fall
+// back to the OS-native input via the Preferences -> Pickers toggles. 12- vs
+// 24-hour display follows the Time & date preference.
 //
 // `value` is a Date (local time); `onChange` reports a new Date. Seconds are
 // zeroed so logged times are clean.
@@ -28,6 +30,7 @@ export function DateTimePicker({
   const { prefs } = usePrefs();
   const hour12 = prefs.hour12;
   const [showClock, setShowClock] = useState(false);
+  const [showCal, setShowCal] = useState(false);
 
   const hours = value.getHours();
   const minutes = value.getMinutes();
@@ -53,29 +56,66 @@ export function DateTimePicker({
   const timeLabel = hour12
     ? `${displayHour}:${pad(minutes)} ${isPM ? "PM" : "AM"}`
     : `${pad(hours)}:${pad(minutes)}`;
+  const dateLabel = value.toLocaleDateString(undefined, { dateStyle: "medium" });
 
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
-        <input
-          type="date"
-          aria-label="Date"
-          className={INPUT}
-          value={toDateInput(value)}
-          max={max ? toDateInput(max) : undefined}
-          onChange={(e) => e.target.value && emitDate(e.target.value)}
-        />
-        <button
-          type="button"
-          onClick={() => setShowClock((s) => !s)}
-          className={`${INPUT} min-w-[92px] text-left tabular-nums`}
-          aria-expanded={showClock}
-        >
-          {timeLabel}
-        </button>
+        {prefs.datePicker ? (
+          <button
+            type="button"
+            onClick={() => setShowCal((s) => !s)}
+            className={`${INPUT} min-w-[140px] text-left`}
+            aria-expanded={showCal}
+          >
+            {dateLabel}
+          </button>
+        ) : (
+          <input
+            type="date"
+            aria-label="Date"
+            className={INPUT}
+            value={toDateInput(value)}
+            max={max ? toDateInput(max) : undefined}
+            onChange={(e) => e.target.value && emitDate(e.target.value)}
+          />
+        )}
+
+        {prefs.timePicker ? (
+          <button
+            type="button"
+            onClick={() => setShowClock((s) => !s)}
+            className={`${INPUT} min-w-[92px] text-left tabular-nums`}
+            aria-expanded={showClock}
+          >
+            {timeLabel}
+          </button>
+        ) : (
+          <input
+            type="time"
+            aria-label="Time"
+            className={INPUT}
+            value={`${pad(hours)}:${pad(minutes)}`}
+            onChange={(e) => {
+              const [h, m] = e.target.value.split(":").map(Number);
+              if (!Number.isNaN(h) && !Number.isNaN(m)) emitTime(h, m);
+            }}
+          />
+        )}
       </div>
 
-      {showClock && (
+      {prefs.datePicker && showCal && (
+        <DatePickerCalendar
+          value={value}
+          max={max}
+          onChange={(d) => {
+            emitDate(toDateInput(d));
+            setShowCal(false);
+          }}
+        />
+      )}
+
+      {prefs.timePicker && showClock && (
         <div className="rounded-lg border bg-muted/20 p-3">
           <ClockPicker hours={hours} minutes={minutes} hour12={hour12} onChange={emitTime} />
         </div>

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -36,7 +36,12 @@ export function TaskCard({
   const { prefs } = usePrefs();
   const status = stalenessTint(
     task,
-    { fresh: prefs.taskColorFresh, overdue: prefs.taskColorOverdue, noRoutineFadeDays: prefs.noRoutineFadeDays },
+    {
+      fresh: prefs.taskColorFresh,
+      overdue: prefs.taskColorOverdue,
+      noRoutineFadeDays: prefs.noRoutineFadeDays,
+      disableFade: !prefs.colorFade,
+    },
     now,
   );
   const due = nextDue(task);
@@ -156,7 +161,7 @@ export function TaskCard({
                 {due && (
                   <>
                     {" · "}
-                    <span className={cn(formatDue(due, now).overdue && !task.freezeColor && "text-rose-400")}>
+                    <span className={cn(formatDue(due, now).overdue && !task.freezeColor && prefs.colorFade && "text-rose-400")}>
                       {formatDue(due, now).text}
                     </span>
                   </>

--- a/web/src/components/settings/PreferencesSection.tsx
+++ b/web/src/components/settings/PreferencesSection.tsx
@@ -2,7 +2,6 @@ import {
   type AddButtonPosition,
   type CardSize,
   type ClockChoice,
-  type ColorPickerStyle,
   type DateOrder,
   usePrefs,
 } from "@/lib/prefs";
@@ -77,46 +76,78 @@ export function PreferencesSection() {
             background: `linear-gradient(90deg, ${prefs.taskColorFresh}, ${prefs.taskColorOverdue})`,
           }}
         />
-        <div className="flex items-center justify-between gap-2 pt-1">
-          <Label className="text-xs text-muted-foreground">
-            No-routine fade: {prefs.noRoutineFadeDays}d
-          </Label>
+        <label className="flex items-center justify-between gap-2 pt-1 text-sm">
+          <span className="text-muted-foreground">
+            Fade colours over time
+            <span className="block text-xs">
+              Off keeps every task at its recent colour — no need for per-task freeze.
+            </span>
+          </span>
           <input
-            type="range"
-            min={1}
-            max={30}
-            step={1}
-            value={prefs.noRoutineFadeDays}
-            onChange={(e) => setPrefs({ noRoutineFadeDays: Number(e.target.value) })}
-            className="w-32 accent-primary"
-            aria-label="Days for a routine-less task to fade to overdue"
+            type="checkbox"
+            className="h-4 w-4 shrink-0 accent-primary"
+            checked={prefs.colorFade}
+            onChange={(e) => setPrefs({ colorFade: e.target.checked })}
           />
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label className="text-xs text-muted-foreground">Colour picker</Label>
-            <select
-              className={SELECT}
-              value={prefs.colorPicker}
-              onChange={(e) => setPrefs({ colorPicker: e.target.value as ColorPickerStyle })}
-            >
-              <option value="wheel" className="bg-background">Built-in wheel</option>
-              <option value="native" className="bg-background">System picker</option>
-            </select>
+        </label>
+        {prefs.colorFade && (
+          <div className="flex items-center justify-between gap-2">
+            <Label className="text-xs text-muted-foreground">
+              No-routine fade: {prefs.noRoutineFadeDays}d
+            </Label>
+            <input
+              type="range"
+              min={1}
+              max={30}
+              step={1}
+              value={prefs.noRoutineFadeDays}
+              onChange={(e) => setPrefs({ noRoutineFadeDays: Number(e.target.value) })}
+              className="w-32 accent-primary"
+              aria-label="Days for a routine-less task to fade to overdue"
+            />
           </div>
-          <div className="space-y-1">
-            <Label className="text-xs text-muted-foreground">Add button (mobile)</Label>
-            <select
-              className={SELECT}
-              value={prefs.addButton}
-              onChange={(e) => setPrefs({ addButton: e.target.value as AddButtonPosition })}
-            >
-              <option value="top" className="bg-background">Top right</option>
-              <option value="bottom" className="bg-background">Bottom (FAB)</option>
-            </select>
-          </div>
+        )}
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Add button (mobile)</Label>
+          <select
+            className={SELECT}
+            value={prefs.addButton}
+            onChange={(e) => setPrefs({ addButton: e.target.value as AddButtonPosition })}
+          >
+            <option value="top" className="bg-background">Top right</option>
+            <option value="bottom" className="bg-background">Bottom (FAB)</option>
+          </select>
         </div>
       </section>
+
+      {/* Pickers: Taskrr's own controls on by default; turn one off for the
+          device's native input. */}
+      <details className="rounded-lg border">
+        <summary className="cursor-pointer select-none px-3 py-2 text-sm font-semibold">Pickers</summary>
+        <div className="space-y-2.5 border-t p-3">
+          <p className="text-[11px] text-muted-foreground">
+            Taskrr's own pickers are on by default; turn one off to use your device's native control.
+          </p>
+          <AnimToggle
+            label="Custom colour picker"
+            hint="A colour wheel instead of the system picker"
+            checked={prefs.colorPicker === "wheel"}
+            onChange={(v) => setPrefs({ colorPicker: v ? "wheel" : "native" })}
+          />
+          <AnimToggle
+            label="Custom date picker"
+            hint="A calendar instead of the system date input"
+            checked={prefs.datePicker}
+            onChange={(v) => setPrefs({ datePicker: v })}
+          />
+          <AnimToggle
+            label="Custom time picker"
+            hint="An analog clock instead of the system time input"
+            checked={prefs.timePicker}
+            onChange={(v) => setPrefs({ timePicker: v })}
+          />
+        </div>
+      </details>
 
       {/* Layout & motion */}
       <section className="space-y-2">

--- a/web/src/components/ui/DatePickerCalendar.tsx
+++ b/web/src/components/ui/DatePickerCalendar.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const pad = (n: number) => String(n).padStart(2, "0");
+const key = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+/**
+ * DatePickerCalendar is a compact month grid for choosing a single date — the
+ * same look as the app's main Calendar, used by DateTimePicker when the custom
+ * date picker preference is on. `value`/`onChange` are local Dates (time of day
+ * untouched). `max` optionally caps selectable days (e.g. "no future").
+ */
+export function DatePickerCalendar({
+  value,
+  onChange,
+  max,
+}: {
+  value: Date;
+  onChange: (d: Date) => void;
+  max?: Date;
+}) {
+  const [view, setView] = useState(() => new Date(value.getFullYear(), value.getMonth(), 1));
+
+  const year = view.getFullYear();
+  const month = view.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const leadingBlanks = new Date(year, month, 1).getDay();
+  const selectedKey = key(value);
+  const todayKey = key(new Date());
+  const maxKey = max ? key(max) : null;
+
+  const cells: (number | null)[] = [
+    ...Array.from({ length: leadingBlanks }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+
+  const pick = (day: number) => {
+    const d = new Date(value);
+    d.setFullYear(year, month, day);
+    onChange(d);
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">
+          {view.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
+        </h3>
+        <div className="flex gap-1">
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Previous month"
+            onClick={() => setView(new Date(year, month - 1, 1))}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Next month"
+            onClick={() => setView(new Date(year, month + 1, 1))}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+      <div className="grid select-none grid-cols-7 gap-1 text-center text-[10px] text-muted-foreground">
+        {WEEKDAYS.map((d) => (
+          <div key={d} className="py-1">{d}</div>
+        ))}
+      </div>
+      <div className="grid select-none grid-cols-7 gap-1">
+        {cells.map((day, i) => {
+          if (day === null) return <div key={`b${i}`} />;
+          const cellKey = key(new Date(year, month, day));
+          const disabled = maxKey != null && cellKey > maxKey;
+          const isToday = cellKey === todayKey;
+          const isSelected = cellKey === selectedKey;
+          return (
+            <button
+              key={cellKey}
+              type="button"
+              disabled={disabled}
+              onClick={() => pick(day)}
+              className={cn(
+                "flex aspect-square items-center justify-center rounded-md text-xs transition-colors",
+                isSelected
+                  ? "bg-primary font-medium text-primary-foreground"
+                  : "hover:bg-accent",
+                isToday && !isSelected && "ring-1 ring-primary",
+                disabled && "cursor-not-allowed opacity-30 hover:bg-transparent",
+              )}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/prefs.tsx
+++ b/web/src/lib/prefs.tsx
@@ -43,6 +43,13 @@ export interface Prefs {
   noRoutineFadeDays: number;
   /** Which colour picker to use: the built-in wheel or the OS-native input. */
   colorPicker: ColorPickerStyle;
+  /** Use Taskrr's calendar date picker (true) or the OS-native date input. */
+  datePicker: boolean;
+  /** Use Taskrr's analog clock time picker (true) or the OS-native time input. */
+  timePicker: boolean;
+  /** Fade task colours from fresh→overdue over time. Off = every task stays at
+   *  its fresh colour (a global version of per-task freeze-colour). */
+  colorFade: boolean;
   /** Where the mobile "add task" button lives. */
   addButton: AddButtonPosition;
 
@@ -124,6 +131,9 @@ function defaults(): Prefs {
     taskColorOverdue: "#ef4444", // red
     noRoutineFadeDays: 7,
     colorPicker: "wheel",
+    datePicker: true,
+    timePicker: true,
+    colorFade: true,
     addButton: "top",
     cardSize: "comfortable",
     taskColumns: 0,

--- a/web/src/lib/staleness.ts
+++ b/web/src/lib/staleness.ts
@@ -105,6 +105,10 @@ export interface StalenessTintOptions {
   overdue: string;
   /** Days over which a no-cadence task fades fully to `overdue`. */
   noRoutineFadeDays: number;
+  /** When true, no task fades — every task stays at its fresh colour (the
+   *  per-user "disable colour fade" preference, equivalent to freeze-colour on
+   *  every task). Cadence, due dates, and filters are unaffected. */
+  disableFade?: boolean;
 }
 
 export interface StalenessTint {
@@ -148,7 +152,8 @@ export function stalenessTint(
 
   // "Stay green": pin the colour (and the displayed bucket) to fresh, regardless
   // of how overdue the task actually is. Cadence/due/filters are untouched.
-  if (task.freezeColor) {
+  // Triggered per-task (freezeColor) or globally (the disableFade preference).
+  if (task.freezeColor || opts.disableFade) {
     return {
       key: "fresh",
       label: STYLES.fresh.label,


### PR DESCRIPTION
Three of the smaller items you led with. **Stacked on #8** (it builds on #8's prefs changes) — merge #8 first and this diff resolves to just the changes below.

## Global colour-fade toggle

Preferences → Task colours gains **"Fade colours over time"** (on by default). Turn it off and every task stays at its recent colour — no need to set per-task freeze-colour on each one. It reuses the same code path as freeze-colour in `stalenessTint`, so cadence, due dates, and filters are unaffected; only the colour (and the rose "overdue" text) is pinned. The no-routine fade slider hides when fading is off, since it's moot.

## Custom date picker + a "Pickers" preference group

New `DatePickerCalendar` — a compact month-grid date picker styled like the main calendar (prev/next month, today ring, optional max date). The log/edit date-time control now uses it for the date, alongside the existing analog clock for the time.

A new collapsible **Pickers** section (on-by-default toggles, same model as the colour wheel) lets each be switched to the device's native input:
- Custom colour picker (wheel ↔ system)
- Custom date picker (calendar ↔ native date input)
- Custom time picker (analog clock ↔ native time input)

The 12/24-hour and date-format choices stay in Time & date.

## Admins: pop the Logs out as a window

The live log tail is factored into a shared `LogsView`; the Logs section keeps its inline collapsible (polls only while expanded) and adds a **Pop out** button that opens the same view as a floating window. Now you can leave logs open and watch them while using other settings windows to test changes — exactly what you asked for.

Typecheck, Vitest, and the production build pass; verified in a headless demo capture that the date picker renders as a custom control (not a native input), the Pickers section and fade toggle render, and there are no page errors.

Version 1.7.0. Branding is still queued, then the big phases you outlined (shared tasks, then organization).

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_