### PR TITLE
Date-picker month/year chooser, theme-share for users, toasts, collapsible theme sections (v1.8.0)

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -35,6 +35,9 @@ const (
 	// keyThemesShareable: when true, admins can publish a saved theme to every
 	// user (the "Share" button in the theme customizer).
 	keyThemesShareable = "themes_shareable"
+	// keyThemesShareUsers: when true (and sharing is on), non-admin users may
+	// share themes too, not just admins.
+	keyThemesShareUsers = "themes_share_users"
 	// keySharedThemes: the JSON array of admin-published themes, available to all.
 	keySharedThemes = "shared_themes"
 )
@@ -188,6 +191,7 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 		"defaultTheme":        defaultTheme,
 		"defaultThemeEnforce": s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		"themesShareable":     s.boolSetting(ctx, keyThemesShareable, false),
+		"themesShareUsers":    s.boolSetting(ctx, keyThemesShareUsers, false),
 	})
 }
 
@@ -1331,6 +1335,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		keyOIDCOnly:              s.boolSetting(ctx, keyOIDCOnly, false),
 		keyDefaultThemeEnforce:   s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		keyThemesShareable:       s.boolSetting(ctx, keyThemesShareable, false),
+		keyThemesShareUsers:      s.boolSetting(ctx, keyThemesShareUsers, false),
 		"oidc_client_secret_set": get(keyOIDCClientSecret) != "", // never return the secret
 		"oidc_enabled":           s.oidcEnabled(ctx),
 	})
@@ -1351,6 +1356,7 @@ type settingsPatch struct {
 	OIDCOnly            *bool   `json:"oidc_only"`
 	DefaultThemeEnforce *bool   `json:"default_theme_enforce"`
 	ThemesShareable     *bool   `json:"themes_shareable"`
+	ThemesShareUsers    *bool   `json:"themes_share_users"`
 }
 
 func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
@@ -1406,6 +1412,9 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.ThemesShareable != nil && !set(keyThemesShareable, boolStr(*req.ThemesShareable)) {
+		return
+	}
+	if req.ThemesShareUsers != nil && !set(keyThemesShareUsers, boolStr(*req.ThemesShareUsers)) {
 		return
 	}
 	// Only overwrite the secret when a new, non-empty one is provided. Encrypt it

--- a/internal/api/themes.go
+++ b/internal/api/themes.go
@@ -37,13 +37,20 @@ func (s *Server) handleListSharedThemes(w http.ResponseWriter, r *http.Request) 
 }
 
 // handleShareTheme publishes (or replaces, by name) a theme so every user can
-// apply it. Admin-only, and gated on the themes_shareable setting being on.
+// apply it. Gated on the themes_shareable setting; admins may always share,
+// regular users only when themes_share_users is also on.
 func (s *Server) handleShareTheme(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r); !ok {
+	u, ok := s.requireUser(w, r)
+	if !ok {
 		return
 	}
 	if !s.boolSetting(r.Context(), keyThemesShareable, false) {
 		writeError(w, http.StatusForbidden, "theme sharing is disabled")
+		return
+	}
+	// Admins can always share; regular users only when the admin has allowed it.
+	if u.Role != "admin" && !s.boolSetting(r.Context(), keyThemesShareUsers, false) {
+		writeError(w, http.StatusForbidden, "only admins can share themes here")
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, 256<<10)) // 256 KiB per theme is ample

--- a/internal/api/themes_test.go
+++ b/internal/api/themes_test.go
@@ -89,11 +89,19 @@ func TestSharedThemes(t *testing.T) {
 		t.Fatalf("re-share same name should replace; got %d themes", len(list))
 	}
 
-	// A non-admin cannot publish.
+	// A non-admin cannot publish by default.
 	w = httptest.NewRecorder()
 	s.handleShareTheme(w, authed("POST", `{"name":"Sneaky"}`, user))
 	if w.Code != 403 {
 		t.Fatalf("non-admin share = %d, want 403", w.Code)
+	}
+
+	// ...but can once the admin allows everyone to share.
+	_ = st.SetSetting(ctx, keyThemesShareUsers, "true")
+	w = httptest.NewRecorder()
+	s.handleShareTheme(w, authed("POST", `{"name":"Sunrise","colors":{"accent":"#ee9b00"}}`, user))
+	if w.Code != 200 {
+		t.Fatalf("non-admin share with themes_share_users on = %d, want 200 (%s)", w.Code, w.Body.String())
 	}
 
 	// Unshare by name.

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/settings/ThemeCustomizer.tsx
+++ b/web/src/components/settings/ThemeCustomizer.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { ColorField } from "@/components/ui/ColorPicker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/Toast";
 
 const SELECT =
   "h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -58,6 +59,7 @@ export function ThemeCustomizer() {
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [name, setName] = useState("");
   const [harmony, setHarmony] = useState<Harmony>("complementary");
   const fileRef = useRef<HTMLInputElement>(null);
@@ -309,8 +311,9 @@ export function ThemeCustomizer() {
       </section>
 
       {/* Background effect */}
-      <section className="space-y-2">
-        <h3 className="text-sm font-semibold">Background</h3>
+      <details className="rounded-lg border">
+        <summary className="cursor-pointer select-none px-3 py-2 text-sm font-semibold">Background</summary>
+        <div className="space-y-2 border-t p-3">
         <select
           className={SELECT}
           value={theme.background}
@@ -412,11 +415,13 @@ export function ThemeCustomizer() {
             />
           </div>
         )}
-      </section>
+        </div>
+      </details>
 
       {/* Save / share */}
-      <section className="space-y-2">
-        <h3 className="text-sm font-semibold">Save &amp; share</h3>
+      <details className="rounded-lg border">
+        <summary className="cursor-pointer select-none px-3 py-2 text-sm font-semibold">Save &amp; share</summary>
+        <div className="space-y-2 border-t p-3">
         <div className="flex gap-2">
           <Input
             value={name}
@@ -440,12 +445,17 @@ export function ThemeCustomizer() {
                   <span className="truncate">{t.name}</span>
                 </button>
                 <div className="flex shrink-0 items-center gap-2">
-                  {/* Admins can publish a saved theme to all users when sharing
-                      is enabled for the instance. */}
-                  {isAdmin && config?.themesShareable && (
+                  {/* Publish a saved theme to all users when sharing is enabled —
+                      admins always, regular users when the admin allows it. */}
+                  {config?.themesShareable && (isAdmin || config?.themesShareUsers) && (
                     <button
                       type="button"
-                      onClick={() => share.mutate(t)}
+                      onClick={(e) => {
+                        const anchor = e.currentTarget;
+                        share.mutate(t, {
+                          onSuccess: () => toast("Shared with everyone", { anchor, tone: "success" }),
+                        });
+                      }}
                       disabled={share.isPending}
                       title="Share with everyone"
                       className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary disabled:opacity-50"
@@ -526,9 +536,26 @@ export function ThemeCustomizer() {
                 onChange={(e) => saveSetting.mutate({ themes_shareable: e.target.checked })}
               />
             </label>
+            {settings?.themes_shareable && (
+              <label className="flex items-center justify-between gap-2 pl-3 text-sm">
+                <span className="text-muted-foreground">
+                  Let everyone share
+                  <span className="block text-xs">
+                    Regular users get the Share button too, not just admins.
+                  </span>
+                </span>
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 shrink-0 accent-primary"
+                  checked={settings?.themes_share_users ?? false}
+                  onChange={(e) => saveSetting.mutate({ themes_share_users: e.target.checked })}
+                />
+              </label>
+            )}
           </div>
         )}
-      </section>
+        </div>
+      </details>
 
       <Button
         type="button"

--- a/web/src/components/ui/DatePickerCalendar.tsx
+++ b/web/src/components/ui/DatePickerCalendar.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const MONTH_LABELS = Array.from({ length: 12 }, (_, m) =>
+  new Date(2000, m, 1).toLocaleDateString(undefined, { month: "short" }),
+);
 const pad = (n: number) => String(n).padStart(2, "0");
 const key = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 
@@ -24,6 +27,9 @@ export function DatePickerCalendar({
   max?: Date;
 }) {
   const [view, setView] = useState(() => new Date(value.getFullYear(), value.getMonth(), 1));
+  // Month/year chooser: clicking the title swaps the day grid for it.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerYear, setPickerYear] = useState(() => value.getFullYear());
 
   const year = view.getFullYear();
   const month = view.getMonth();
@@ -44,23 +50,83 @@ export function DatePickerCalendar({
     onChange(d);
   };
 
+  const gotoMonth = (y: number, m: number) => {
+    setView(new Date(y, m, 1));
+    setPickerOpen(false);
+  };
+
   return (
     <div className="rounded-lg border bg-card p-3">
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-sm font-semibold">
+        <button
+          type="button"
+          onClick={() => {
+            setPickerYear(year);
+            setPickerOpen((o) => !o);
+          }}
+          aria-expanded={pickerOpen}
+          title="Pick a month and year"
+          className="group flex items-center gap-1 rounded text-sm font-semibold transition-colors hover:text-primary"
+        >
           {view.toLocaleDateString(undefined, { month: "long", year: "numeric" })}
-        </h3>
+          <ChevronDown
+            className={cn(
+              "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200 group-hover:text-primary",
+              pickerOpen && "rotate-180",
+            )}
+          />
+        </button>
         <div className="flex gap-1">
           <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Previous month"
-            onClick={() => setView(new Date(year, month - 1, 1))}>
+            onClick={() => { setPickerOpen(false); setView(new Date(year, month - 1, 1)); }}>
             <ChevronLeft className="h-4 w-4" />
           </Button>
           <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Next month"
-            onClick={() => setView(new Date(year, month + 1, 1))}>
+            onClick={() => { setPickerOpen(false); setView(new Date(year, month + 1, 1)); }}>
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
       </div>
+
+      {pickerOpen ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Previous year"
+              onClick={() => setPickerYear((y) => y - 1)}>
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium tabular-nums">{pickerYear}</span>
+            <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Next year"
+              onClick={() => setPickerYear((y) => y + 1)}>
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="grid grid-cols-3 gap-1">
+            {MONTH_LABELS.map((label, m) => {
+              const now = new Date();
+              const isViewed = pickerYear === year && m === month;
+              const isThisMonth = pickerYear === now.getFullYear() && m === now.getMonth();
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => gotoMonth(pickerYear, m)}
+                  className={cn(
+                    "rounded-md py-2 text-xs transition-colors",
+                    isViewed
+                      ? "bg-primary/15 font-medium text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                    isThisMonth && !isViewed && "ring-1 ring-primary/40",
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+      <>
       <div className="grid select-none grid-cols-7 gap-1 text-center text-[10px] text-muted-foreground">
         {WEEKDAYS.map((d) => (
           <div key={d} className="py-1">{d}</div>
@@ -93,6 +159,8 @@ export function DatePickerCalendar({
           );
         })}
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,125 @@
+import {
+  createContext,
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+// A small, modular toast system. Call the function from useToast() to flash a
+// brief message — either anchored just above a clicked element, or pinned to a
+// screen corner/edge. Kept deliberately generic so any button can use it.
+
+export type ToastPlacement =
+  | "top-left"
+  | "top-right"
+  | "top-center"
+  | "bottom-left"
+  | "bottom-right"
+  | "bottom-center";
+
+export interface ToastOptions {
+  /** Show the toast just above this element (e.g. the button that was clicked).
+   *  Takes precedence over `placement`. */
+  anchor?: HTMLElement | null;
+  /** Fixed screen position when there's no anchor. Default "bottom-right". */
+  placement?: ToastPlacement;
+  /** Auto-dismiss after this many ms (default 2000). */
+  duration?: number;
+  /** Visual tone. */
+  tone?: "default" | "success" | "error";
+}
+
+interface ToastItem {
+  id: number;
+  message: string;
+  style: CSSProperties;
+  enter: string;
+  tone: NonNullable<ToastOptions["tone"]>;
+}
+
+type ShowToast = (message: string, opts?: ToastOptions) => void;
+
+const ToastCtx = createContext<ShowToast>(() => {});
+
+/** Returns `toast(message, opts?)`. Safe to call from anywhere under the app. */
+export function useToast(): ShowToast {
+  return useContext(ToastCtx);
+}
+
+let nextId = 1;
+const MARGIN = 16;
+
+function positionFor(opts: ToastOptions): { style: CSSProperties; enter: string } {
+  // Anchored: float centred just above the element, in viewport coordinates
+  // (the portal container is fixed at inset-0, so these map 1:1).
+  if (opts.anchor) {
+    const r = opts.anchor.getBoundingClientRect();
+    return {
+      style: { left: r.left + r.width / 2, top: r.top - 8, transform: "translate(-50%, -100%)" },
+      enter: "slide-in-from-bottom-1",
+    };
+  }
+  const placement = opts.placement ?? "bottom-right";
+  const style: CSSProperties = {};
+  const top = placement.startsWith("top");
+  if (top) style.top = MARGIN;
+  else style.bottom = MARGIN;
+  if (placement.endsWith("center")) {
+    style.left = "50%";
+    style.transform = "translateX(-50%)";
+  } else if (placement.endsWith("left")) {
+    style.left = MARGIN;
+  } else {
+    style.right = MARGIN;
+  }
+  return { style, enter: top ? "slide-in-from-top-2" : "slide-in-from-bottom-2" };
+}
+
+const TONES: Record<NonNullable<ToastOptions["tone"]>, string> = {
+  default: "border-border bg-card text-foreground",
+  success: "border-emerald-500/40 bg-card text-foreground",
+  error: "border-destructive/50 bg-card text-destructive",
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const show = useCallback<ShowToast>((message, opts = {}) => {
+    const id = nextId++;
+    const { style, enter } = positionFor(opts);
+    setToasts((cur) => [...cur, { id, message, style, enter, tone: opts.tone ?? "default" }]);
+    window.setTimeout(() => {
+      setToasts((cur) => cur.filter((t) => t.id !== id));
+    }, opts.duration ?? 2000);
+  }, []);
+
+  return (
+    <ToastCtx.Provider value={show}>
+      {children}
+      {createPortal(
+        <div aria-live="polite" className="pointer-events-none fixed inset-0 z-[100]">
+          {toasts.map((t) => (
+            <div
+              key={t.id}
+              style={t.style}
+              className={cn(
+                "absolute max-w-[80vw] truncate rounded-md border px-3 py-1.5 text-xs font-medium shadow-lg",
+                "animate-in fade-in-0 zoom-in-95 duration-150",
+                t.enter,
+                TONES[t.tone],
+              )}
+            >
+              {t.message}
+            </div>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </ToastCtx.Provider>
+  );
+}

--- a/web/src/lib/api.demo.ts
+++ b/web/src/lib/api.demo.ts
@@ -302,6 +302,7 @@ const DEMO_AUTH: AuthConfig = {
   defaultTheme: null,
   defaultThemeEnforce: false,
   themesShareable: false,
+  themesShareUsers: false,
 };
 
 const DEMO_REMINDERS: ReminderSettings = { enabled: false, webhookUrl: "", leadSeconds: 0 };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -90,6 +90,8 @@ export interface AuthConfig {
   defaultThemeEnforce: boolean;
   /** Admins may publish saved themes to all users. */
   themesShareable: boolean;
+  /** Regular users (not just admins) may publish themes too. */
+  themesShareUsers: boolean;
 }
 
 /** Registration may complete (User) or be queued for approval. */
@@ -149,6 +151,7 @@ export interface AdminSettings {
   oidc_only: boolean;
   default_theme_enforce: boolean;
   themes_shareable: boolean;
+  themes_share_users: boolean;
   oidc_client_secret_set: boolean;
   oidc_enabled: boolean;
 }
@@ -166,6 +169,7 @@ export type SettingsPatch = Partial<{
   oidc_only: boolean;
   default_theme_enforce: boolean;
   themes_shareable: boolean;
+  themes_share_users: boolean;
 }>;
 
 /** Fields a user can set when creating or editing a task. */

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { AuthProvider } from "@/components/AuthProvider";
 import { PrefsProvider } from "@/lib/prefs";
 import { WindowManagerProvider } from "@/components/windows/WindowManager";
+import { ToastProvider } from "@/components/ui/Toast";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -24,9 +25,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <ThemeProvider>
         <PrefsProvider>
           <AuthProvider>
-            <WindowManagerProvider>
-              <Gate />
-            </WindowManagerProvider>
+            <ToastProvider>
+              <WindowManagerProvider>
+                <Gate />
+              </WindowManagerProvider>
+            </ToastProvider>
           </AuthProvider>
         </PrefsProvider>
       </ThemeProvider>


### PR DESCRIPTION
Stacked on #8 and #9; merge those first and this resolves to just the changes below.

## Date-picker month/year chooser

The custom date picker (`DatePickerCalendar`) gains the same month/year chooser the main calendar has: clicking its title swaps the day grid for a year-stepped 3×4 month grid (current view highlighted, today's month ringed).

## Theme sharing for regular users

New `themes_share_users` setting. When theme sharing is on, an admin toggle ("Let everyone share", under Site themes) additionally lets non-admins publish themes. The Share button now shows for a user when sharing is enabled and either they're an admin or `themes_share_users` is on; the share endpoint enforces the same (non-admins rejected unless it's set). Unsharing stays admin-only.

## Modular toasts

New `ToastProvider` / `useToast()` (`web/src/components/ui/Toast.tsx`). `toast(message, opts)` either anchors the message just above a clicked element (`anchor`) or pins it to a screen corner/edge (`placement`), with a tone and auto-dismiss. Rendered via a portal so it's reusable from anywhere. Wired to the theme Share button (confirms "Shared with everyone" above the button).

## Collapsible theme sections

The theme customizer's **Background** and **Save & share** sections are now collapsible `<details>`, closed by default.

Verified: `go vet` + full Go suite (shared-theme test extended for the user-share gate), frontend typecheck/Vitest/build, and a headless demo capture (date-picker chooser renders, no page errors).

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_