### PR TITLE
Toasts: vertical rise, broad action coverage, per-user disable toggle (v1.9.0)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -8,6 +8,7 @@ import { timeSince } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/AuthProvider";
 import { useWindows } from "@/components/windows/WindowManager";
+import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -129,6 +130,7 @@ const MERGE_SELECT = "h-7 rounded border border-input bg-transparent px-1.5 text
 function SessionsSection() {
   const { user: me } = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [open, setOpen] = useState(false);
   const { data: sessions } = useQuery({
     queryKey: ["sessions"],
@@ -138,7 +140,10 @@ function SessionsSection() {
   });
   const terminate = useMutation({
     mutationFn: (userId: number) => api.terminateSessions(userId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["sessions"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      toast("Signed out everywhere", { tone: "success" });
+    },
   });
 
   return (
@@ -212,6 +217,7 @@ function SessionsSection() {
 function MergeAccounts() {
   const { user: me } = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data: users } = useQuery({ queryKey: ["users"], queryFn: api.listUsers });
   const [sourceId, setSourceId] = useState<number | "">("");
   const [targetId, setTargetId] = useState<number | "">("");
@@ -233,6 +239,7 @@ function MergeAccounts() {
       queryClient.invalidateQueries(); // users + tasks/activity may have moved
       setSourceId("");
       setTargetId("");
+      toast("Accounts merged", { tone: "success" });
     },
   });
 
@@ -338,10 +345,23 @@ function MergeAccounts() {
  *  uploaded .db) — which restarts the server. */
 function BackupsSection() {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data: backups } = useQuery({ queryKey: ["backups"], queryFn: api.listBackups });
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["backups"] });
-  const create = useMutation({ mutationFn: () => api.createBackup(), onSuccess: invalidate });
-  const del = useMutation({ mutationFn: (name: string) => api.deleteBackup(name), onSuccess: invalidate });
+  const create = useMutation({
+    mutationFn: () => api.createBackup(),
+    onSuccess: () => {
+      invalidate();
+      toast("Backup created", { tone: "success" });
+    },
+  });
+  const del = useMutation({
+    mutationFn: (name: string) => api.deleteBackup(name),
+    onSuccess: () => {
+      invalidate();
+      toast("Backup deleted", { tone: "success" });
+    },
+  });
 
   const [restarting, setRestarting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -586,6 +606,7 @@ function RegistrationSettings() {
 /** Accounts awaiting approval (shown only when there are any). */
 function PendingUsers() {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data: pending } = useQuery({
     queryKey: ["pending-users"],
     queryFn: api.listPending,
@@ -597,9 +618,18 @@ function PendingUsers() {
   };
   const approve = useMutation({
     mutationFn: (v: { id: number; role: "admin" | "user" }) => api.approveUser(v.id, v.role),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate();
+      toast("User approved", { tone: "success" });
+    },
   });
-  const deny = useMutation({ mutationFn: (id: number) => api.adminDeleteUser(id), onSuccess: invalidate });
+  const deny = useMutation({
+    mutationFn: (id: number) => api.adminDeleteUser(id),
+    onSuccess: () => {
+      invalidate();
+      toast("Request denied", { tone: "success" });
+    },
+  });
 
   if (!pending || pending.length === 0) return null;
 
@@ -663,6 +693,7 @@ function PendingRow({
 
 function OIDCSettings() {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data } = useQuery({ queryKey: ["settings"], queryFn: api.getSettings });
   const [form, setForm] = useState<SettingsPatch>({});
   const [secret, setSecret] = useState("");
@@ -672,10 +703,11 @@ function OIDCSettings() {
   const save = useMutation({
     mutationFn: (extra: SettingsPatch | undefined) =>
       api.putSettings({ ...form, ...(secret ? { oidc_client_secret: secret } : {}), ...(extra ?? {}) }),
-    onSuccess: (next) => {
+    onSuccess: (next, extra) => {
       queryClient.setQueryData(["settings"], next);
       setForm({});
       setSecret("");
+      if (extra === undefined) toast("OIDC settings saved", { tone: "success" });
     },
   });
 
@@ -774,6 +806,7 @@ function OIDCSettings() {
 function Users() {
   const { user: me } = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data: users } = useQuery({ queryKey: ["users"], queryFn: api.listUsers });
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["users"] });
 
@@ -793,11 +826,17 @@ function Users() {
   const update = useMutation({
     mutationFn: (v: { id: number; role?: "admin" | "user"; password?: string }) =>
       api.adminUpdateUser(v.id, { role: v.role, password: v.password }),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate();
+      toast("Saved", { tone: "success" });
+    },
   });
   const remove = useMutation({
     mutationFn: (id: number) => api.adminDeleteUser(id),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate();
+      toast("User deleted", { tone: "success" });
+    },
   });
 
   const resetPassword = (u: User) => {

--- a/web/src/components/BulkBar.tsx
+++ b/web/src/components/BulkBar.tsx
@@ -5,6 +5,7 @@ import { Archive, ArchiveRestore, CheckCheck, Trash2, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { usePrefs } from "@/lib/prefs";
 import { cn } from "@/lib/utils";
+import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 
 type BulkAction = "done" | "archive" | "unarchive" | "delete";
@@ -26,6 +27,7 @@ export function BulkBar({
 }) {
   const queryClient = useQueryClient();
   const { prefs } = usePrefs();
+  const toast = useToast();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const run = useMutation({
@@ -35,11 +37,18 @@ export function BulkBar({
       else if (action === "unarchive") await Promise.all(ids.map((id) => api.unarchiveTask(id)));
       else await Promise.all(ids.map((id) => api.deleteTask(id)));
     },
-    onSuccess: () => {
+    onSuccess: (_data, action) => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       queryClient.invalidateQueries({ queryKey: ["activity"] });
       setConfirmDelete(false);
       onClear();
+      const labels: Record<BulkAction, string> = {
+        done: "Logged",
+        archive: "Archived",
+        unarchive: "Restored",
+        delete: "Deleted",
+      };
+      toast(`${labels[action]} ${ids.length} ${ids.length === 1 ? "task" : "tasks"}`, { tone: "success" });
     },
   });
 

--- a/web/src/components/CompleteTaskDialog.tsx
+++ b/web/src/components/CompleteTaskDialog.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 
 import { api, type Task } from "@/lib/api";
+import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -19,6 +20,7 @@ export function CompleteTaskPanel({ task, onClose }: { task: Task; onClose: () =
   const [when, setWhen] = useState(() => new Date());
   const queryClient = useQueryClient();
 
+  const toast = useToast();
   const mutation = useMutation({
     mutationFn: () =>
       api.completeTask(task.id, {
@@ -30,6 +32,7 @@ export function CompleteTaskPanel({ task, onClose }: { task: Task; onClose: () =
       queryClient.invalidateQueries({ queryKey: ["completions", task.id] });
       queryClient.invalidateQueries({ queryKey: ["activity"] });
       onClose();
+      toast("Logged", { tone: "success" });
     },
   });
 

--- a/web/src/components/CreateTaskDialog.tsx
+++ b/web/src/components/CreateTaskDialog.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 
 import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -30,6 +31,7 @@ export function CreateTaskDialog({ trigger }: { trigger?: React.ReactNode }) {
   const [intervalSeconds, setIntervalSeconds] = useState<number | null>(null);
   const queryClient = useQueryClient();
 
+  const toast = useToast();
   const mutation = useMutation({
     mutationFn: () =>
       api.createTask({
@@ -43,6 +45,7 @@ export function CreateTaskDialog({ trigger }: { trigger?: React.ReactNode }) {
       setDescription("");
       setIntervalSeconds(null);
       setOpen(false);
+      toast("Task created", { tone: "success" });
     },
   });
 

--- a/web/src/components/ManageTaskDialog.tsx
+++ b/web/src/components/ManageTaskDialog.tsx
@@ -6,6 +6,7 @@ import { api, type Completion, type Task } from "@/lib/api";
 import { formatDateTime } from "@/lib/time";
 import { usePrefs } from "@/lib/prefs";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/Toast";
 import { ColorField } from "@/components/ui/ColorPicker";
 import { DateTimePicker } from "@/components/DateTimePicker";
 import { Input } from "@/components/ui/input";
@@ -50,6 +51,7 @@ function EditSection({ task, onDone }: { task: Task; onDone: () => void }) {
   const [freezeColor, setFreezeColor] = useState(task.freezeColor);
   const queryClient = useQueryClient();
 
+  const toast = useToast();
   const mutation = useMutation({
     mutationFn: () =>
       api.updateTask(task.id, {
@@ -63,6 +65,7 @@ function EditSection({ task, onDone }: { task: Task; onDone: () => void }) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       onDone();
+      toast("Task saved", { tone: "success" });
     },
   });
 
@@ -254,6 +257,7 @@ function HistoryRow({ completion: c, onChanged }: { completion: Completion; onCh
 function DangerZone({ task, onDeleted }: { task: Task; onDeleted: () => void }) {
   const [confirming, setConfirming] = useState(false);
   const queryClient = useQueryClient();
+  const toast = useToast();
   const archived = task.archivedAt != null;
 
   const mutation = useMutation({
@@ -262,6 +266,7 @@ function DangerZone({ task, onDeleted }: { task: Task; onDeleted: () => void }) 
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       queryClient.invalidateQueries({ queryKey: ["activity"] });
       onDeleted();
+      toast("Task deleted", { tone: "success" });
     },
   });
 
@@ -270,6 +275,7 @@ function DangerZone({ task, onDeleted }: { task: Task; onDeleted: () => void }) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       onDeleted();
+      toast(archived ? "Task restored" : "Task archived", { tone: "success" });
     },
   });
 

--- a/web/src/components/settings/AccountSection.tsx
+++ b/web/src/components/settings/AccountSection.tsx
@@ -8,11 +8,13 @@ import { useAuth } from "@/components/AuthProvider";
 import { RemindersSection } from "@/components/settings/RemindersSection";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/Toast";
 
 /** Account self-service: every signed-in user can change their own username + password. */
 export function AccountSection() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const toast = useToast();
   const [username, setUsername] = useState(user?.username ?? "");
   const [current, setCurrent] = useState("");
   const [next, setNext] = useState("");
@@ -43,6 +45,7 @@ export function AccountSection() {
       setWipeConfirm("");
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       queryClient.invalidateQueries({ queryKey: ["activity"] });
+      toast("Your tasks were deleted", { tone: "success" });
     },
   });
 
@@ -63,6 +66,7 @@ export function AccountSection() {
       // Reflect the new name immediately and refresh the admin list if open.
       queryClient.setQueryData(["me"], updated);
       queryClient.invalidateQueries({ queryKey: ["users"] });
+      toast("Username updated", { tone: "success" });
     },
   });
 
@@ -73,6 +77,7 @@ export function AccountSection() {
       setNext("");
       setConfirm("");
       setErr(null);
+      toast("Password updated", { tone: "success" });
     },
     onError: (e) => setErr((e as Error).message),
   });

--- a/web/src/components/settings/PreferencesSection.tsx
+++ b/web/src/components/settings/PreferencesSection.tsx
@@ -181,6 +181,15 @@ export function PreferencesSection() {
           </div>
         </div>
         <label className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">Toast notifications</span>
+          <input
+            type="checkbox"
+            className="h-4 w-4 accent-primary"
+            checked={prefs.toasts}
+            onChange={(e) => setPrefs({ toasts: e.target.checked })}
+          />
+        </label>
+        <label className="flex items-center justify-between gap-2 text-sm">
           <span className="text-muted-foreground">Show calendar</span>
           <input
             type="checkbox"

--- a/web/src/components/settings/RemindersSection.tsx
+++ b/web/src/components/settings/RemindersSection.tsx
@@ -5,6 +5,7 @@ import { Bell, ChevronRight } from "lucide-react";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/Toast";
 
 const LEAD_OPTIONS: { label: string; value: number }[] = [
   { label: "When it's due", value: 0 },
@@ -18,6 +19,7 @@ const LEAD_OPTIONS: { label: string; value: number }[] = [
 /** Reminders: deliver a webhook when one of your tasks comes due. */
 export function RemindersSection() {
   const queryClient = useQueryClient();
+  const toast = useToast();
   const { data } = useQuery({ queryKey: ["reminders"], queryFn: api.getReminders });
 
   const [enabled, setEnabled] = useState(false);
@@ -46,9 +48,14 @@ export function RemindersSection() {
     onSuccess: (updated) => {
       queryClient.setQueryData(["reminders"], updated);
       apply(updated); // reflect any server-side normalisation
+      toast("Reminders saved", { tone: "success" });
     },
   });
-  const test = useMutation({ mutationFn: () => api.testReminder(webhookUrl.trim()) });
+  const test = useMutation({
+    mutationFn: () => api.testReminder(webhookUrl.trim()),
+    onSuccess: () => toast("Test webhook sent", { tone: "success" }),
+    onError: (e) => toast((e as Error).message, { tone: "error" }),
+  });
 
   const canSave = !enabled || webhookUrl.trim() !== "";
 

--- a/web/src/components/settings/ThemeCustomizer.tsx
+++ b/web/src/components/settings/ThemeCustomizer.tsx
@@ -63,7 +63,10 @@ export function ThemeCustomizer() {
   const [name, setName] = useState("");
   const [harmony, setHarmony] = useState<Harmony>("complementary");
   const fileRef = useRef<HTMLInputElement>(null);
-  const setDefault = useMutation({ mutationFn: () => api.setDefaultTheme(theme) });
+  const setDefault = useMutation({
+    mutationFn: () => api.setDefaultTheme(theme),
+    onSuccess: () => toast("Saved as the site default", { tone: "success" }),
+  });
 
   // Saved themes now live in the account's prefs (server-side), so they follow
   // the account and survive logout — they used to be in localStorage and got
@@ -114,6 +117,7 @@ export function ThemeCustomizer() {
     if (!trimmed) return;
     setPrefs({ savedThemes: [...saved.filter((t) => t.name !== trimmed), { ...theme, name: trimmed }] });
     setName("");
+    toast("Theme saved", { tone: "success" });
   }
   const remove = (n: string) => setPrefs({ savedThemes: saved.filter((t) => t.name !== n) });
 
@@ -129,7 +133,10 @@ export function ThemeCustomizer() {
   function importTheme(file: File) {
     file
       .text()
-      .then((text) => applyTheme({ ...DEFAULT_THEME, ...(JSON.parse(text) as Theme) }))
+      .then((text) => {
+        applyTheme({ ...DEFAULT_THEME, ...(JSON.parse(text) as Theme) });
+        toast("Theme imported", { tone: "success" });
+      })
       .catch(() => alert("That file isn't a valid Taskrr theme."));
   }
 

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -9,6 +9,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { cn } from "@/lib/utils";
+import { usePrefs } from "@/lib/prefs";
 
 // A small, modular toast system. Call the function from useToast() to flash a
 // brief message — either anchored just above a clicked element, or pinned to a
@@ -38,7 +39,6 @@ interface ToastItem {
   id: number;
   message: string;
   style: CSSProperties;
-  enter: string;
   tone: NonNullable<ToastOptions["tone"]>;
 }
 
@@ -54,20 +54,19 @@ export function useToast(): ShowToast {
 let nextId = 1;
 const MARGIN = 16;
 
-function positionFor(opts: ToastOptions): { style: CSSProperties; enter: string } {
+// The fixed position of the toast's outer wrapper. The rise/fade animation
+// lives on an inner element so it never fights this positioning transform
+// (animating both on one node is what made the old toast slide in diagonally).
+function positionFor(opts: ToastOptions): CSSProperties {
   // Anchored: float centred just above the element, in viewport coordinates
   // (the portal container is fixed at inset-0, so these map 1:1).
   if (opts.anchor) {
     const r = opts.anchor.getBoundingClientRect();
-    return {
-      style: { left: r.left + r.width / 2, top: r.top - 8, transform: "translate(-50%, -100%)" },
-      enter: "slide-in-from-bottom-1",
-    };
+    return { left: r.left + r.width / 2, top: r.top - 8, transform: "translate(-50%, -100%)" };
   }
   const placement = opts.placement ?? "bottom-right";
   const style: CSSProperties = {};
-  const top = placement.startsWith("top");
-  if (top) style.top = MARGIN;
+  if (placement.startsWith("top")) style.top = MARGIN;
   else style.bottom = MARGIN;
   if (placement.endsWith("center")) {
     style.left = "50%";
@@ -77,7 +76,7 @@ function positionFor(opts: ToastOptions): { style: CSSProperties; enter: string 
   } else {
     style.right = MARGIN;
   }
-  return { style, enter: top ? "slide-in-from-top-2" : "slide-in-from-bottom-2" };
+  return style;
 }
 
 const TONES: Record<NonNullable<ToastOptions["tone"]>, string> = {
@@ -87,16 +86,21 @@ const TONES: Record<NonNullable<ToastOptions["tone"]>, string> = {
 };
 
 export function ToastProvider({ children }: { children: ReactNode }) {
+  const { prefs } = usePrefs();
   const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const enabled = prefs.toasts;
 
-  const show = useCallback<ShowToast>((message, opts = {}) => {
-    const id = nextId++;
-    const { style, enter } = positionFor(opts);
-    setToasts((cur) => [...cur, { id, message, style, enter, tone: opts.tone ?? "default" }]);
-    window.setTimeout(() => {
-      setToasts((cur) => cur.filter((t) => t.id !== id));
-    }, opts.duration ?? 2000);
-  }, []);
+  const show = useCallback<ShowToast>(
+    (message, opts = {}) => {
+      if (!enabled) return; // the user has turned toast notifications off
+      const id = nextId++;
+      setToasts((cur) => [...cur, { id, message, style: positionFor(opts), tone: opts.tone ?? "default" }]);
+      window.setTimeout(() => {
+        setToasts((cur) => cur.filter((t) => t.id !== id));
+      }, opts.duration ?? 2000);
+    },
+    [enabled],
+  );
 
   return (
     <ToastCtx.Provider value={show}>
@@ -104,17 +108,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       {createPortal(
         <div aria-live="polite" className="pointer-events-none fixed inset-0 z-[100]">
           {toasts.map((t) => (
-            <div
-              key={t.id}
-              style={t.style}
-              className={cn(
-                "absolute max-w-[80vw] truncate rounded-md border px-3 py-1.5 text-xs font-medium shadow-lg",
-                "animate-in fade-in-0 zoom-in-95 duration-150",
-                t.enter,
-                TONES[t.tone],
-              )}
-            >
-              {t.message}
+            // Outer node: fixed position. Inner node: the rise+fade, so the
+            // animation can't disturb the positioning transform above.
+            <div key={t.id} style={t.style} className="absolute">
+              <div
+                className={cn(
+                  "max-w-[80vw] truncate rounded-md border px-3 py-1.5 text-xs font-medium shadow-lg",
+                  "animate-in fade-in-0 slide-in-from-bottom-2 duration-200",
+                  TONES[t.tone],
+                )}
+              >
+                {t.message}
+              </div>
             </div>
           ))}
         </div>,

--- a/web/src/lib/prefs.tsx
+++ b/web/src/lib/prefs.tsx
@@ -82,6 +82,8 @@ export interface Prefs {
   /** Eased mouse-wheel scrolling (rAF-driven, so it interpolates at the
    *  display's refresh rate). Touchpads/touch keep native scrolling. */
   smoothScroll: boolean;
+  /** Show brief toast notifications for actions (save, delete, log, …). */
+  toasts: boolean;
 
   // --- themes ---
   /** The user's saved named themes. Persisted server-side with the rest of
@@ -147,6 +149,7 @@ function defaults(): Prefs {
     animWindows: true,
     animViews: true,
     smoothScroll: true,
+    toasts: true,
     savedThemes: [],
     themeCustom: false,
     draggableWindows: true,


### PR DESCRIPTION
## Toast entrance

Reworked so it's a clean fade + upward rise instead of a diagonal slide: the fixed positioning lives on an outer element and the rise/fade animation on an inner one, so the animation no longer fights the positioning transform (the cause of the diagonal motion). Applies to both anchored and corner toasts.

## Broad toast coverage

Wired the modular toast onto actions that previously had little or no feedback:
- Tasks: create, advanced log, archive/restore, delete; bulk done/archive/restore/delete (with counts).
- Account: username change, password change, wipe-my-data.
- Reminders: save, send test (and test errors).
- Admin: create/delete backup, add/save/delete user, approve/deny pending, terminate sessions, merge accounts, save OIDC.
- Theme: save, set as site default, import (share already had one).

Surfaces that close on success use a corner toast; the OIDC save toast only fires on the explicit Save (not the inline toggles), and the wipe action keeps its existing inline message.

## Per-user disable

New "Toast notifications" preference (Preferences, on by default). When off, `ToastProvider` suppresses every toast.

Typecheck, Vitest, and the production build pass; confirmed in a headless demo capture that a toast renders on action with no page errors.

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_