### PR TITLE
Instance branding: name, title, tagline, uploaded icon, login-card toggles (v1.10.0)

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -40,6 +40,21 @@ const (
 	keyThemesShareUsers = "themes_share_users"
 	// keySharedThemes: the JSON array of admin-published themes, available to all.
 	keySharedThemes = "shared_themes"
+
+	// --- branding (admin-editable; shown signed-out, so exposed in authConfig) ---
+	keyBrandName     = "brand_name"      // app name in the sidebar + login
+	keyBrandTitle    = "brand_title"     // browser tab / document title
+	keyBrandTagline  = "brand_tagline"   // the small subtitle under the name
+	keyBrandIcon     = "brand_icon"      // a data-URL logo; "" = generated mark
+	keyLoginHideIcon = "login_hide_icon" // hide the icon on the login card
+	keyLoginHideText = "login_hide_text" // hide the name/tagline on the login card
+)
+
+// Branding defaults (used when a setting is unset/empty).
+const (
+	defaultBrandName    = "Taskrr"
+	defaultBrandTagline = "last-done tracker"
+	maxBrandIconBytes   = 256 << 10 // 256 KiB data URL cap
 )
 
 type userCtxKey struct{}
@@ -130,6 +145,28 @@ func (s *Server) boolSetting(ctx context.Context, key string, def bool) bool {
 	return v == "true"
 }
 
+// stringSetting returns a stored string setting, or def when unset/empty.
+func (s *Server) stringSetting(ctx context.Context, key, def string) string {
+	v, ok, err := s.store.GetSetting(ctx, key)
+	if err != nil || !ok || v == "" {
+		return def
+	}
+	return v
+}
+
+// branding gathers the instance's customisable identity for the SPA. It's part
+// of authConfig because the login screen (signed out) needs it.
+func (s *Server) branding(ctx context.Context) map[string]any {
+	return map[string]any{
+		"name":          s.stringSetting(ctx, keyBrandName, defaultBrandName),
+		"title":         s.stringSetting(ctx, keyBrandTitle, ""),
+		"tagline":       s.stringSetting(ctx, keyBrandTagline, defaultBrandTagline),
+		"icon":          s.stringSetting(ctx, keyBrandIcon, ""),
+		"loginHideIcon": s.boolSetting(ctx, keyLoginHideIcon, false),
+		"loginHideText": s.boolSetting(ctx, keyLoginHideText, false),
+	}
+}
+
 func (s *Server) setSessionCookie(w http.ResponseWriter, token string, expires time.Time) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookie,
@@ -192,6 +229,7 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 		"defaultThemeEnforce": s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		"themesShareable":     s.boolSetting(ctx, keyThemesShareable, false),
 		"themesShareUsers":    s.boolSetting(ctx, keyThemesShareUsers, false),
+		"branding":            s.branding(ctx),
 	})
 }
 
@@ -1336,6 +1374,12 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		keyDefaultThemeEnforce:   s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		keyThemesShareable:       s.boolSetting(ctx, keyThemesShareable, false),
 		keyThemesShareUsers:      s.boolSetting(ctx, keyThemesShareUsers, false),
+		keyBrandName:             get(keyBrandName),
+		keyBrandTitle:            get(keyBrandTitle),
+		keyBrandTagline:          get(keyBrandTagline),
+		keyBrandIcon:             get(keyBrandIcon),
+		keyLoginHideIcon:         s.boolSetting(ctx, keyLoginHideIcon, false),
+		keyLoginHideText:         s.boolSetting(ctx, keyLoginHideText, false),
 		"oidc_client_secret_set": get(keyOIDCClientSecret) != "", // never return the secret
 		"oidc_enabled":           s.oidcEnabled(ctx),
 	})
@@ -1357,6 +1401,12 @@ type settingsPatch struct {
 	DefaultThemeEnforce *bool   `json:"default_theme_enforce"`
 	ThemesShareable     *bool   `json:"themes_shareable"`
 	ThemesShareUsers    *bool   `json:"themes_share_users"`
+	BrandName           *string `json:"brand_name"`
+	BrandTitle          *string `json:"brand_title"`
+	BrandTagline        *string `json:"brand_tagline"`
+	BrandIcon           *string `json:"brand_icon"`
+	LoginHideIcon       *bool   `json:"login_hide_icon"`
+	LoginHideText       *bool   `json:"login_hide_text"`
 }
 
 func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
@@ -1415,6 +1465,37 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.ThemesShareUsers != nil && !set(keyThemesShareUsers, boolStr(*req.ThemesShareUsers)) {
+		return
+	}
+	// Branding. The icon is a data URL (or empty to clear); cap its size so it
+	// can't bloat the settings row / every authConfig response.
+	if req.BrandName != nil && !set(keyBrandName, strings.TrimSpace(*req.BrandName)) {
+		return
+	}
+	if req.BrandTitle != nil && !set(keyBrandTitle, strings.TrimSpace(*req.BrandTitle)) {
+		return
+	}
+	if req.BrandTagline != nil && !set(keyBrandTagline, strings.TrimSpace(*req.BrandTagline)) {
+		return
+	}
+	if req.BrandIcon != nil {
+		icon := strings.TrimSpace(*req.BrandIcon)
+		if len(icon) > maxBrandIconBytes {
+			writeError(w, http.StatusBadRequest, "icon is too large (max 256 KB)")
+			return
+		}
+		if icon != "" && !strings.HasPrefix(icon, "data:image/") {
+			writeError(w, http.StatusBadRequest, "icon must be an uploaded image")
+			return
+		}
+		if !set(keyBrandIcon, icon) {
+			return
+		}
+	}
+	if req.LoginHideIcon != nil && !set(keyLoginHideIcon, boolStr(*req.LoginHideIcon)) {
+		return
+	}
+	if req.LoginHideText != nil && !set(keyLoginHideText, boolStr(*req.LoginHideText)) {
 		return
 	}
 	// Only overwrite the secret when a new, non-empty one is provided. Encrypt it

--- a/internal/api/branding_test.go
+++ b/internal/api/branding_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/unmaykr-a/taskrr/internal/store"
+)
+
+// TestBrandingDefaultsAndSave: authConfig reports branding defaults, a save
+// round-trips, and the icon is validated.
+func TestBranding(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	admin, _ := st.CreateUser(ctx, store.UserInput{Username: "admin", Role: "admin", PasswordHash: ptr("h")})
+	s := NewServer(st, Options{ProtectedUserID: admin.ID})
+	h := s.Handler()
+
+	// Defaults via authConfig (public).
+	cfgW := httptest.NewRecorder()
+	h.ServeHTTP(cfgW, httptest.NewRequest("GET", "/api/auth/config", nil))
+	if !strings.Contains(cfgW.Body.String(), `"name":"Taskrr"`) ||
+		!strings.Contains(cfgW.Body.String(), `"tagline":"last-done tracker"`) {
+		t.Fatalf("branding defaults missing: %s", cfgW.Body.String())
+	}
+
+	put := func(body string) int {
+		req := authed("PUT", body, admin)
+		w := httptest.NewRecorder()
+		s.handlePutSettings(w, req)
+		return w.Code
+	}
+
+	// A valid save round-trips into authConfig.
+	if code := put(`{"brand_name":"Choreroo","brand_tagline":"chores, sorted","brand_icon":"data:image/png;base64,AAAA"}`); code != 200 {
+		t.Fatalf("save branding = %d, want 200", code)
+	}
+	cfgW = httptest.NewRecorder()
+	h.ServeHTTP(cfgW, httptest.NewRequest("GET", "/api/auth/config", nil))
+	if !strings.Contains(cfgW.Body.String(), `"name":"Choreroo"`) {
+		t.Fatalf("brand name not applied: %s", cfgW.Body.String())
+	}
+
+	// A non-image icon is rejected.
+	if code := put(`{"brand_icon":"javascript:alert(1)"}`); code != 400 {
+		t.Fatalf("non-image icon = %d, want 400", code)
+	}
+	// An oversized icon is rejected.
+	if code := put(`{"brand_icon":"data:image/png;base64,` + strings.Repeat("A", 300<<10) + `"}`); code != 400 {
+		t.Fatalf("oversized icon = %d, want 400", code)
+	}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#6366f1" />
+    <meta name="theme-color" content="#ec8a9a" />
     <meta
       name="description"
       content="Taskrr — a lightweight, self-hosted tracker for when you last did things."

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <rect width="32" height="32" rx="8" fill="#6366f1" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="4" y="4" width="56" height="56" rx="16" fill="#ec8a9a" />
   <path
-    d="M9 16.5l4.5 4.5L23 11"
+    d="M19 33l9 10 18-20"
     fill="none"
-    stroke="#fff"
-    stroke-width="3"
+    stroke="#3a1620"
+    stroke-width="7"
     stroke-linecap="round"
     stroke-linejoin="round"
   />

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronRight, ExternalLink, Trash2, UserPlus, X } from "lucide-react";
+import { CheckCircle2, ChevronRight, ExternalLink, Trash2, UserPlus, X } from "lucide-react";
 
 import { api, type SettingsPatch, type User } from "@/lib/api";
 import { clearStoredPreferences } from "@/lib/prefs";
@@ -31,6 +31,8 @@ export function AdminPanel() {
         </>
       )}
       <OIDCSettings />
+      <hr className="border-border/60" />
+      <BrandingSettings />
       <hr className="border-border/60" />
       <PendingUsers />
       {!lite && <Users />}
@@ -118,6 +120,161 @@ function LogsSection() {
           </button>
         </div>
         {open && <LogsView />}
+      </div>
+    </details>
+  );
+}
+
+/** Branding: instance name, tab title, tagline, a custom icon, and login-card
+ *  toggles. Saved together; the live UI (sidebar, title, favicon) refreshes via
+ *  the auth-config cache. */
+function BrandingSettings() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const { data } = useQuery({ queryKey: ["settings"], queryFn: api.getSettings });
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState("");
+  const [title, setTitle] = useState("");
+  const [tagline, setTagline] = useState("");
+  const [icon, setIcon] = useState("");
+  const [hideIcon, setHideIcon] = useState(false);
+  const [hideText, setHideText] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Seed the form from the server once.
+  useEffect(() => {
+    if (data && !hydrated) {
+      setName(data.brand_name ?? "");
+      setTitle(data.brand_title ?? "");
+      setTagline(data.brand_tagline ?? "");
+      setIcon(data.brand_icon ?? "");
+      setHideIcon(data.login_hide_icon ?? false);
+      setHideText(data.login_hide_text ?? false);
+      setHydrated(true);
+    }
+  }, [data, hydrated]);
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.putSettings({
+        brand_name: name.trim(),
+        brand_title: title.trim(),
+        brand_tagline: tagline.trim(),
+        brand_icon: icon,
+        login_hide_icon: hideIcon,
+        login_hide_text: hideText,
+      }),
+    onSuccess: (next) => {
+      queryClient.setQueryData(["settings"], next);
+      queryClient.invalidateQueries({ queryKey: ["auth-config"] }); // refresh live branding
+      toast("Branding saved", { tone: "success" });
+    },
+    onError: (e) => toast((e as Error).message, { tone: "error" }),
+  });
+
+  // Downscale any uploaded image to a 128x128 PNG (cover) so the stored data
+  // URL stays small (well under the server's 256 KB cap) and crisp as a favicon.
+  function onPickFile(file: File) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const sizePx = 128;
+        const c = document.createElement("canvas");
+        c.width = sizePx;
+        c.height = sizePx;
+        const ctx = c.getContext("2d");
+        if (!ctx) return;
+        const scale = Math.max(sizePx / img.width, sizePx / img.height);
+        const w = img.width * scale;
+        const h = img.height * scale;
+        ctx.drawImage(img, (sizePx - w) / 2, (sizePx - h) / 2, w, h);
+        setIcon(c.toDataURL("image/png"));
+      };
+      img.onerror = () => toast("That file isn't an image", { tone: "error" });
+      img.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  return (
+    <details className="rounded-lg border">
+      <summary className="cursor-pointer select-none px-3 py-2 text-sm font-semibold">Branding</summary>
+      <div className="space-y-3 border-t p-3">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Name</Label>
+          <Input value={name} placeholder="Taskrr" onChange={(e) => setName(e.target.value)} className="h-8" />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Browser tab title</Label>
+          <Input value={title} placeholder="(defaults to the name)" onChange={(e) => setTitle(e.target.value)} className="h-8" />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Tagline</Label>
+          <Input value={tagline} placeholder="last-done tracker" onChange={(e) => setTagline(e.target.value)} className="h-8" />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Icon</Label>
+          <div className="flex items-center gap-2">
+            {icon ? (
+              <img src={icon} alt="" className="h-9 w-9 shrink-0 rounded-lg object-cover" />
+            ) : (
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+                <CheckCircle2 className="h-5 w-5" />
+              </div>
+            )}
+            <Button type="button" variant="outline" size="sm" onClick={() => fileRef.current?.click()}>
+              Upload
+            </Button>
+            {icon && (
+              <button
+                type="button"
+                onClick={() => setIcon("")}
+                className="text-xs text-muted-foreground hover:text-destructive"
+              >
+                remove
+              </button>
+            )}
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                e.target.value = "";
+                if (f) onPickFile(f);
+              }}
+            />
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Used for the tab icon, the sidebar, and the login card. Square images work best.
+          </p>
+        </div>
+        <label className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">Hide icon on the login page</span>
+          <input
+            type="checkbox"
+            className="h-4 w-4 shrink-0 accent-primary"
+            checked={hideIcon}
+            onChange={(e) => setHideIcon(e.target.checked)}
+          />
+        </label>
+        <label className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">Hide name &amp; tagline on the login page</span>
+          <input
+            type="checkbox"
+            className="h-4 w-4 shrink-0 accent-primary"
+            checked={hideText}
+            onChange={(e) => setHideText(e.target.checked)}
+          />
+        </label>
+        <div className="flex justify-end">
+          <Button size="sm" disabled={save.isPending} onClick={() => save.mutate()}>
+            {save.isPending ? "Saving…" : "Save branding"}
+          </Button>
+        </div>
       </div>
     </details>
   );

--- a/web/src/components/AuthPage.tsx
+++ b/web/src/components/AuthPage.tsx
@@ -11,6 +11,7 @@ import {
   type User,
 } from "@/lib/api";
 import { useTheme } from "@/components/ThemeProvider";
+import { useBranding } from "@/components/Branding";
 import { DEFAULT_THEME } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,7 @@ export function AuthPage() {
   const queryClient = useQueryClient();
   const { setTheme } = useTheme();
   const { data: config } = useQuery({ queryKey: ["auth-config"], queryFn: api.authConfig });
+  const branding = useBranding();
   const [tab, setTab] = useState<Tab>("login");
   const tabsRef = useRef<HTMLDivElement>(null);
   const [username, setUsername] = useState("");
@@ -99,15 +101,24 @@ export function AuthPage() {
     <div className="relative z-10 h-[100dvh] overflow-y-auto">
       <div className="flex min-h-full items-center justify-center p-4">
         <div className="w-full max-w-sm rounded-2xl border bg-card/95 p-6 shadow-2xl backdrop-blur">
-        <div className="mb-6 flex flex-col items-center gap-2 text-center">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow">
-            <CheckCircle2 className="h-6 w-6" />
+        {(!branding.loginHideIcon || !branding.loginHideText) && (
+          <div className="mb-6 flex flex-col items-center gap-2 text-center">
+            {!branding.loginHideIcon &&
+              (branding.icon ? (
+                <img src={branding.icon} alt="" className="h-11 w-11 rounded-xl object-cover shadow" />
+              ) : (
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow">
+                  <CheckCircle2 className="h-6 w-6" />
+                </div>
+              ))}
+            {!branding.loginHideText && (
+              <div>
+                <h1 className="text-lg font-semibold tracking-tight">{branding.name}</h1>
+                {branding.tagline && <p className="text-xs text-muted-foreground">{branding.tagline}</p>}
+              </div>
+            )}
           </div>
-          <div>
-            <h1 className="text-lg font-semibold tracking-tight">Taskrr</h1>
-            <p className="text-xs text-muted-foreground">last-done tracker</p>
-          </div>
-        </div>
+        )}
 
         {pending ? (
           <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-4 text-center text-sm">

--- a/web/src/components/Branding.tsx
+++ b/web/src/components/Branding.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { api, type Branding as BrandingData } from "@/lib/api";
+import { setBrandIcon } from "@/lib/theme";
+
+const DEFAULTS: BrandingData = {
+  name: "Taskrr",
+  title: "",
+  tagline: "last-done tracker",
+  icon: "",
+  loginHideIcon: false,
+  loginHideText: false,
+};
+
+/** Read the instance branding from auth config (with defaults). Available
+ *  signed-in and signed-out, since the login page is branded too. */
+export function useBranding(): BrandingData {
+  const { data } = useQuery({ queryKey: ["auth-config"], queryFn: api.authConfig });
+  return data?.branding ?? DEFAULTS;
+}
+
+/**
+ * Applies the instance branding that lives outside React's tree: the document
+ * (tab) title and the favicon. Mounted once near the root; renders nothing.
+ */
+export function BrandingApplier() {
+  const branding = useBranding();
+
+  useEffect(() => {
+    document.title = branding.title.trim() || branding.name.trim() || "Taskrr";
+  }, [branding.title, branding.name]);
+
+  // A custom icon overrides the generated checkmark favicon; clearing it falls
+  // back to the theme-coloured mark.
+  useEffect(() => {
+    setBrandIcon(branding.icon || null);
+  }, [branding.icon]);
+
+  return null;
+}

--- a/web/src/components/Gate.tsx
+++ b/web/src/components/Gate.tsx
@@ -4,6 +4,7 @@ import App from "@/App";
 import { useAuth } from "@/components/AuthProvider";
 import { AuthPage } from "@/components/AuthPage";
 import { Background } from "@/components/Background";
+import { BrandingApplier } from "@/components/Branding";
 import { DemoBanner } from "@/components/DemoBanner";
 
 /**
@@ -16,6 +17,7 @@ export function Gate() {
 
   return (
     <>
+      <BrandingApplier />
       <Background />
       {loading ? (
         <div className="relative z-10 flex min-h-[100dvh] items-center justify-center">

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { type Filter, FILTERS } from "@/lib/filters";
 import { clearStoredPreferences, usePrefs } from "@/lib/prefs";
 import { DEFAULT_THEME } from "@/lib/theme";
 import { cn } from "@/lib/utils";
+import { useBranding } from "@/components/Branding";
 import { Button } from "@/components/ui/button";
 import { SlidingHighlight } from "@/components/ui/SlidingHighlight";
 import { CreateTaskDialog } from "@/components/CreateTaskDialog";
@@ -40,6 +41,7 @@ export function Sidebar({
   const { user } = useAuth();
   const { setTheme } = useTheme();
   const { prefs } = usePrefs();
+  const branding = useBranding();
   const navRef = useRef<HTMLElement>(null);
   // Signing out: close every open window and wipe the query cache so the next
   // account never sees the previous user's tasks/calendar (their data is
@@ -62,13 +64,19 @@ export function Sidebar({
   return (
     <div className="flex h-full w-60 flex-col overflow-y-auto border-r border-border/60 bg-sidebar p-4">
       <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow">
-            <CheckCircle2 className="h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-base font-semibold leading-none tracking-tight">Taskrr</h1>
-            <p className="text-[11px] text-muted-foreground">last-done tracker</p>
+        <div className="flex min-w-0 items-center gap-2.5">
+          {branding.icon ? (
+            <img src={branding.icon} alt="" className="h-9 w-9 shrink-0 rounded-lg object-cover shadow" />
+          ) : (
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow">
+              <CheckCircle2 className="h-5 w-5" />
+            </div>
+          )}
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-semibold leading-none tracking-tight">{branding.name}</h1>
+            {branding.tagline && (
+              <p className="truncate text-[11px] text-muted-foreground">{branding.tagline}</p>
+            )}
           </div>
         </div>
         {/* Close button only matters in the mobile drawer. */}

--- a/web/src/lib/api.demo.ts
+++ b/web/src/lib/api.demo.ts
@@ -303,6 +303,14 @@ const DEMO_AUTH: AuthConfig = {
   defaultThemeEnforce: false,
   themesShareable: false,
   themesShareUsers: false,
+  branding: {
+    name: "Taskrr",
+    title: "",
+    tagline: "last-done tracker",
+    icon: "",
+    loginHideIcon: false,
+    loginHideText: false,
+  },
 };
 
 const DEMO_REMINDERS: ReminderSettings = { enabled: false, webhookUrl: "", leadSeconds: 0 };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -92,6 +92,24 @@ export interface AuthConfig {
   themesShareable: boolean;
   /** Regular users (not just admins) may publish themes too. */
   themesShareUsers: boolean;
+  /** Instance branding (name, title, icon, login toggles). */
+  branding: Branding;
+}
+
+/** Customisable instance identity, shown signed-out and signed-in. */
+export interface Branding {
+  /** App name in the sidebar + login (defaults to "Taskrr"). */
+  name: string;
+  /** Browser-tab title; empty means fall back to the name. */
+  title: string;
+  /** Small subtitle under the name. */
+  tagline: string;
+  /** A custom logo as a data URL; empty means the generated checkmark. */
+  icon: string;
+  /** Hide the icon on the login card. */
+  loginHideIcon: boolean;
+  /** Hide the name/tagline on the login card. */
+  loginHideText: boolean;
 }
 
 /** Registration may complete (User) or be queued for approval. */
@@ -152,6 +170,12 @@ export interface AdminSettings {
   default_theme_enforce: boolean;
   themes_shareable: boolean;
   themes_share_users: boolean;
+  brand_name: string;
+  brand_title: string;
+  brand_tagline: string;
+  brand_icon: string;
+  login_hide_icon: boolean;
+  login_hide_text: boolean;
   oidc_client_secret_set: boolean;
   oidc_enabled: boolean;
 }
@@ -170,6 +194,12 @@ export type SettingsPatch = Partial<{
   default_theme_enforce: boolean;
   themes_shareable: boolean;
   themes_share_users: boolean;
+  brand_name: string;
+  brand_title: string;
+  brand_tagline: string;
+  brand_icon: string;
+  login_hide_icon: boolean;
+  login_hide_text: boolean;
 }>;
 
 /** Fields a user can set when creating or editing a task. */

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -228,9 +228,32 @@ export function applyTheme(theme: Theme) {
 }
 
 /** Recolour the page/tab icon to match the accent (a checkmark on an accent
- *  rounded square), so the favicon tracks the theme to match the theme. */
+ *  rounded square), so the favicon tracks the theme — unless a custom branding
+ *  icon has been set, which then wins. */
+let lastAccent = "#ec8a9a";
+let brandIcon: string | null = null;
+
+/** Set (or clear) the custom branding favicon (a data URL). When set it
+ *  overrides the generated checkmark; pass "" / null to fall back to it. */
+export function setBrandIcon(icon: string | null) {
+  brandIcon = icon && icon.trim() !== "" ? icon : null;
+  setFavicon(lastAccent); // re-render with the new choice
+}
+
 export function setFavicon(accent: string) {
   if (typeof document === "undefined") return;
+  lastAccent = accent;
+
+  // A custom branding icon wins: point the favicon straight at its data URL.
+  if (brandIcon) {
+    document.querySelectorAll("link[rel~='icon']").forEach((l) => l.remove());
+    const link = document.createElement("link");
+    link.rel = "icon";
+    link.href = brandIcon;
+    document.head.appendChild(link);
+    return;
+  }
+
   const canvas = document.createElement("canvas");
   canvas.width = 64;
   canvas.height = 64;


### PR DESCRIPTION
Adds an admin **Branding** section (Admin settings) to customise the instance identity.

## What's configurable
- **Name** — shown in the sidebar and on the login card.
- **Browser tab title** — sets `document.title` (defaults to the name when blank).
- **Tagline** — the small subtitle under the name.
- **Icon** — uploaded image, downscaled client-side to a 128px PNG (cover) so the stored data URL stays small and crisp; used for the favicon, the sidebar mark, and the login card. Falls back to the generated accent checkmark when unset.
- **Login card toggles** — hide the icon and/or the name+tagline on the login page.

## How it's wired
- Settings are stored server-side and returned in `authConfig` (a new `branding` object), so the **signed-out login page is branded too**. The icon is validated (`data:image/…`) and capped at 256 KB server-side.
- A small `BrandingApplier` (mounted in `Gate`, present signed-in and out) sets the document title and, for a custom icon, the favicon — overriding the theme-generated checkmark via a new `setBrandIcon` in the theme module. `useBranding()` feeds the sidebar and login card.
- The static `favicon.svg` and `<meta theme-color>` were recoloured to the default accent checkmark, so the pre-JS bookmark/tab icon matches the in-app one.

## Tests / checks
New backend test (`TestBranding`): authConfig defaults, save round-trip into authConfig, and rejection of a non-image and an oversized icon. Full Go suite, frontend typecheck/Vitest/build all pass; a headless check confirms the document title and sidebar name come from branding with no page errors.

Version 1.10.0.

https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_