### PR TITLE
Shared tasks, organisation, and in-app changelog (v1.11.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ TASKRR_ADMIN_USERNAME=admin
 # safety snapshot on every restore.
 #TASKRR_SAFETY_BACKUP=true
 
+# Source the changelog's "Check for updates" reads to report the latest released
+# version (informational only — it never updates the app). Set empty to disable.
+#TASKRR_UPDATE_CHECK_URL=https://raw.githubusercontent.com/unmaykr-a/taskrr/main/web/package.json
+
 # OIDC single sign-on — also configurable later in the admin UI.
 # A secret containing `$` needs each one doubled to `$$` here.
 #TASKRR_OIDC_ISSUER=https://auth.example.com/application/o/taskrr/

--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ documents every option.
   chart of your last 30 days.
 - Filters with live counts: all, due soon, overdue, never done, archived —
   and bulk actions (log / archive / delete several at once).
+- Keep larger lists tidy: tags (with search and a tag filter), folder grouping,
+  and sorting by name or last-done.
 - Multiple users with per-user data, local password login, and optional OIDC
   single sign-on (tested with Authentik and Pocket ID), including group-to-admin-role
   mapping. A lite mode turns the multi-user surface off for solo use.
+- Share a task with another user so you both see and log it — admin-enabled,
+  with who-logged-last and a per-user opt-out.
 - An admin area in the UI: user management, registration controls with an
   approval queue, active sessions, live server logs, backups with one-click
   restore, and instance settings.
@@ -97,6 +101,7 @@ working examples. The short version:
 | `TASKRR_LITE` | `false` | Single-person mode: disables registration and extra accounts |
 | `TASKRR_REMINDER_INTERVAL` | `1m` | How often the reminder loop checks for due tasks |
 | `TASKRR_SAFETY_BACKUP` | `true` | Snapshot the DB before a restore (so a mistaken restore is undoable); set `false` to skip it |
+| `TASKRR_UPDATE_CHECK_URL` | project package.json | Source the admin changelog's update check reads for the latest version; set empty to disable |
 | `TASKRR_OIDC_*` | — | Issuer, client id/secret, redirect URL — also editable later in the admin UI |
 
 Running behind a reverse proxy with HTTPS is the intended setup for anything

--- a/cmd/taskrr/main.go
+++ b/cmd/taskrr/main.go
@@ -101,6 +101,7 @@ func main() {
 			TrustProxyHeaders:     cfg.TrustProxyHeaders,
 			Secrets:               secrets,
 			SafetyBackupOnRestore: cfg.SafetyBackupOnRestore,
+			UpdateCheckURL:        cfg.UpdateCheckURL,
 		}).Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -40,6 +40,9 @@ const (
 	keyThemesShareUsers = "themes_share_users"
 	// keySharedThemes: the JSON array of admin-published themes, available to all.
 	keySharedThemes = "shared_themes"
+	// keyTasksShareable: admin gate for the whole shared-tasks feature. When off,
+	// the share UI is hidden and the share endpoint refuses new shares.
+	keyTasksShareable = "tasks_shareable"
 
 	// --- branding (admin-editable; shown signed-out, so exposed in authConfig) ---
 	keyBrandName     = "brand_name"      // app name in the sidebar + login
@@ -229,6 +232,7 @@ func (s *Server) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 		"defaultThemeEnforce": s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		"themesShareable":     s.boolSetting(ctx, keyThemesShareable, false),
 		"themesShareUsers":    s.boolSetting(ctx, keyThemesShareUsers, false),
+		"tasksShareable":      s.boolSetting(ctx, keyTasksShareable, false),
 		"branding":            s.branding(ctx),
 	})
 }
@@ -1374,6 +1378,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		keyDefaultThemeEnforce:   s.boolSetting(ctx, keyDefaultThemeEnforce, false),
 		keyThemesShareable:       s.boolSetting(ctx, keyThemesShareable, false),
 		keyThemesShareUsers:      s.boolSetting(ctx, keyThemesShareUsers, false),
+		keyTasksShareable:        s.boolSetting(ctx, keyTasksShareable, false),
 		keyBrandName:             get(keyBrandName),
 		keyBrandTitle:            get(keyBrandTitle),
 		keyBrandTagline:          get(keyBrandTagline),
@@ -1401,6 +1406,7 @@ type settingsPatch struct {
 	DefaultThemeEnforce *bool   `json:"default_theme_enforce"`
 	ThemesShareable     *bool   `json:"themes_shareable"`
 	ThemesShareUsers    *bool   `json:"themes_share_users"`
+	TasksShareable      *bool   `json:"tasks_shareable"`
 	BrandName           *string `json:"brand_name"`
 	BrandTitle          *string `json:"brand_title"`
 	BrandTagline        *string `json:"brand_tagline"`
@@ -1465,6 +1471,9 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.ThemesShareUsers != nil && !set(keyThemesShareUsers, boolStr(*req.ThemesShareUsers)) {
+		return
+	}
+	if req.TasksShareable != nil && !set(keyTasksShareable, boolStr(*req.TasksShareable)) {
 		return
 	}
 	// Branding. The icon is a data URL (or empty to clear); cap its size so it

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -23,8 +23,11 @@ var hexColor = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
 // JSON body cap, and an oversized task name would ride along in every ListTasks
 // response forever.
 const (
-	maxNameLen = 200
-	maxTextLen = 2000 // descriptions and completion notes
+	maxNameLen   = 200
+	maxTextLen   = 2000 // descriptions and completion notes
+	maxTags      = 20
+	maxTagLen    = 40
+	maxFolderLen = 60
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
@@ -49,12 +52,40 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 // taskRequest is the JSON body for creating or updating a task. IntervalSeconds
 // is a pointer so we can tell "not provided / cleared" (null) from a real value.
 type taskRequest struct {
-	Name            string  `json:"name"`
-	Description     string  `json:"description"`
-	IntervalSeconds *int64  `json:"intervalSeconds"`
-	ColorFresh      *string `json:"colorFresh"`
-	ColorOverdue    *string `json:"colorOverdue"`
-	FreezeColor     bool    `json:"freezeColor"`
+	Name            string   `json:"name"`
+	Description     string   `json:"description"`
+	IntervalSeconds *int64   `json:"intervalSeconds"`
+	ColorFresh      *string  `json:"colorFresh"`
+	ColorOverdue    *string  `json:"colorOverdue"`
+	FreezeColor     bool     `json:"freezeColor"`
+	Tags            []string `json:"tags"`
+	Folder          string   `json:"folder"`
+}
+
+// normalizeTags trims, drops empties, caps length, and de-duplicates
+// (case-insensitively, keeping first spelling) the submitted tags.
+func normalizeTags(in []string) ([]string, string) {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]bool)
+	for _, t := range in {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if utf8.RuneCountInString(t) > maxTagLen {
+			return nil, fmt.Sprintf("tags must be at most %d characters", maxTagLen)
+		}
+		key := strings.ToLower(t)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, t)
+	}
+	if len(out) > maxTags {
+		return nil, fmt.Sprintf("a task can have at most %d tags", maxTags)
+	}
+	return out, ""
 }
 
 // toInput validates the request and converts it into a store.TaskInput.
@@ -77,6 +108,14 @@ func (req taskRequest) toInput() (store.TaskInput, string) {
 			return store.TaskInput{}, "colours must be in #rrggbb form, or null"
 		}
 	}
+	tags, msg := normalizeTags(req.Tags)
+	if msg != "" {
+		return store.TaskInput{}, msg
+	}
+	folder := strings.TrimSpace(req.Folder)
+	if utf8.RuneCountInString(folder) > maxFolderLen {
+		return store.TaskInput{}, fmt.Sprintf("folder must be at most %d characters", maxFolderLen)
+	}
 	return store.TaskInput{
 		Name:            name,
 		Description:     strings.TrimSpace(req.Description),
@@ -84,6 +123,8 @@ func (req taskRequest) toInput() (store.TaskInput, string) {
 		ColorFresh:      req.ColorFresh,
 		ColorOverdue:    req.ColorOverdue,
 		FreezeColor:     req.FreezeColor,
+		Tags:            tags,
+		Folder:          folder,
 	}, ""
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,6 +33,19 @@ type TaskStore interface {
 	DeleteCompletion(ctx context.Context, ownerID, id int64) error
 
 	ListActivity(ctx context.Context, ownerID int64, from, to time.Time) ([]store.Activity, error)
+}
+
+// ShareStore is the task-sharing surface: membership lifecycle plus the per-user
+// opt-out. Sharing keeps a task a single row and attaches members, so these sit
+// alongside the owner-scoped TaskStore rather than replacing it.
+type ShareStore interface {
+	ShareTask(ctx context.Context, ownerID, taskID, recipientID int64) (store.TaskShare, error)
+	RespondToShare(ctx context.Context, userID, taskID int64, accept bool) error
+	LeaveTask(ctx context.Context, userID, taskID int64) error
+	ListIncomingShares(ctx context.Context, userID int64) ([]store.ShareRequest, error)
+	ListTaskMembers(ctx context.Context, taskID int64) ([]store.TaskMember, error)
+	GetUserAllowShares(ctx context.Context, id int64) (bool, error)
+	SetUserAllowShares(ctx context.Context, id int64, allow bool) error
 }
 
 // AuthStore is everything the HTTP layer needs for accounts, sessions, and
@@ -88,6 +102,7 @@ type AuthStore interface {
 type Store interface {
 	TaskStore
 	AuthStore
+	ShareStore
 }
 
 // Options carries server-level settings derived from config.
@@ -115,6 +130,9 @@ type Options struct {
 	// SafetyBackupOnRestore takes a backup of the current DB before a restore
 	// swaps it out (so a mistaken restore is recoverable). Default on.
 	SafetyBackupOnRestore bool
+	// UpdateCheckURL is fetched server-side to report the latest released
+	// version (empty disables the check).
+	UpdateCheckURL string
 }
 
 // Server holds the dependencies shared by all HTTP handlers.
@@ -126,6 +144,12 @@ type Server struct {
 	loginLimiter *rateLimiter // per-username attempts
 	ipLimiter    *rateLimiter // per-source-IP attempts (blunts password-spraying)
 	restoring    atomic.Bool  // true while a restore is staged + restart pending
+
+	// Cache for the update check, so repeated opens of the changelog don't hit
+	// the upstream every time.
+	updateMu  sync.Mutex
+	updateVer string
+	updateAt  time.Time
 }
 
 // NewServer constructs a Server backed by the given store.
@@ -188,6 +212,18 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/tasks/{id}/archive", s.handleArchiveTask)
 	mux.HandleFunc("POST /api/tasks/{id}/unarchive", s.handleUnarchiveTask)
 	mux.HandleFunc("DELETE /api/tasks/{id}", s.handleDeleteTask)
+
+	// Sharing: the owner invites a member; members respond/leave; anyone with
+	// access lists members; a user sees their own incoming requests + opt-out.
+	mux.HandleFunc("POST /api/tasks/{id}/share", s.handleShareTask)
+	mux.HandleFunc("POST /api/tasks/{id}/share/respond", s.handleRespondShare)
+	mux.HandleFunc("POST /api/tasks/{id}/leave", s.handleLeaveTask)
+	mux.HandleFunc("GET /api/tasks/{id}/members", s.handleListMembers)
+	mux.HandleFunc("GET /api/me/shares", s.handleListIncomingShares)
+	mux.HandleFunc("PUT /api/me/allow-shares", s.handleSetAllowShares)
+
+	// Latest released version (informational; no in-app update action).
+	mux.HandleFunc("GET /api/version/latest", s.handleCheckVersion)
 
 	mux.HandleFunc("POST /api/tasks/{id}/complete", s.handleCompleteTask)
 	mux.HandleFunc("GET /api/tasks/{id}/completions", s.handleListCompletions)

--- a/internal/api/shares.go
+++ b/internal/api/shares.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/unmaykr-a/taskrr/internal/store"
+)
+
+// --- Shared tasks ---
+//
+// Sharing is admin-gated by the tasks_shareable setting: when off, the share
+// endpoint refuses to create new shares (and the SPA hides the UI). Responding
+// to or leaving an existing share stays available so members can always tidy up.
+
+// handleShareTask lets a task's owner invite another user (by username) as a
+// pending member. POST /api/tasks/{id}/share with {"username": "..."}.
+func (s *Server) handleShareTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	if !s.boolSetting(r.Context(), keyTasksShareable, false) {
+		writeError(w, http.StatusForbidden, "task sharing is disabled on this instance")
+		return
+	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	var req struct {
+		Username string `json:"username"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	name := strings.TrimSpace(req.Username)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "a username is required")
+		return
+	}
+	recipient, err := s.store.GetUserByUsername(r.Context(), name)
+	if err != nil {
+		// Don't leak whether the account exists beyond the generic 404.
+		writeStoreError(w, err, "could not share task")
+		return
+	}
+	share, err := s.store.ShareTask(r.Context(), u.ID, id, recipient.ID)
+	if err != nil {
+		writeShareError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, share)
+}
+
+// handleRespondShare accepts or declines a pending incoming share for the
+// current user. POST /api/tasks/{id}/share/respond with {"accept": true|false}.
+func (s *Server) handleRespondShare(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	var req struct {
+		Accept bool `json:"accept"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if err := s.store.RespondToShare(r.Context(), u.ID, id, req.Accept); err != nil {
+		writeStoreError(w, err, "could not respond to the share")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleLeaveTask removes the current user's membership of a shared task. The
+// task and its history persist for the owner and any other members.
+// POST /api/tasks/{id}/leave.
+func (s *Server) handleLeaveTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	if err := s.store.LeaveTask(r.Context(), u.ID, id); err != nil {
+		writeStoreError(w, err, "could not leave the task")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListMembers returns everyone attached to a task (owner + members), for
+// anyone who can see the task. GET /api/tasks/{id}/members.
+func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	// Gate on visibility: only someone who can see the task may list its members.
+	if _, err := s.store.GetTask(r.Context(), u.ID, id); err != nil {
+		writeStoreError(w, err, "could not list members")
+		return
+	}
+	members, err := s.store.ListTaskMembers(r.Context(), id)
+	if err != nil {
+		writeStoreError(w, err, "could not list members")
+		return
+	}
+	writeJSON(w, http.StatusOK, members)
+}
+
+// handleListIncomingShares returns the current user's pending incoming shares
+// (their Requests view). GET /api/me/shares.
+func (s *Server) handleListIncomingShares(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	reqs, err := s.store.ListIncomingShares(r.Context(), u.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "could not list share requests")
+		return
+	}
+	writeJSON(w, http.StatusOK, reqs)
+}
+
+// handleSetAllowShares sets the current user's opt-in for receiving shared
+// tasks. PUT /api/me/allow-shares with {"allowShares": true|false}.
+func (s *Server) handleSetAllowShares(w http.ResponseWriter, r *http.Request) {
+	u, ok := s.requireUser(w, r)
+	if !ok {
+		return
+	}
+	var req struct {
+		AllowShares bool `json:"allowShares"`
+	}
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if err := s.store.SetUserAllowShares(r.Context(), u.ID, req.AllowShares); err != nil {
+		writeStoreError(w, err, "could not update preference")
+		return
+	}
+	u.AllowShares = req.AllowShares
+	u.Protected = u.ID == s.opts.ProtectedUserID
+	writeJSON(w, http.StatusOK, u)
+}
+
+// writeShareError maps the share-specific sentinel errors to status codes.
+func writeShareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, store.ErrShareSelf):
+		writeError(w, http.StatusBadRequest, "you can't share a task with yourself")
+	case errors.Is(err, store.ErrAlreadyShared):
+		writeError(w, http.StatusConflict, "this task is already shared with that user")
+	case errors.Is(err, store.ErrShareNotAllowed):
+		writeError(w, http.StatusForbidden, "that user isn't accepting shared tasks")
+	case errors.Is(err, store.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not found")
+	default:
+		writeError(w, http.StatusInternalServerError, "could not share task")
+	}
+}

--- a/internal/api/shares_test.go
+++ b/internal/api/shares_test.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/unmaykr-a/taskrr/internal/store"
+)
+
+// shareTestEnv spins up a server with two users (alice the owner, bob the
+// recipient) and a task owned by alice, returning the handler + signed-in
+// cookies. tasksShareable is enabled iff `enabled`.
+type shareTestEnv struct {
+	st     *store.Store
+	h      http.Handler
+	alice  store.User
+	bob    store.User
+	taskID int64
+	cookie map[int64]*http.Cookie
+}
+
+func newShareEnv(t *testing.T, enabled bool) shareTestEnv {
+	t.Helper()
+	ctx := context.Background()
+	st := openStore(t)
+	if enabled {
+		if err := st.SetSetting(ctx, "tasks_shareable", "true"); err != nil {
+			t.Fatalf("SetSetting: %v", err)
+		}
+	}
+	alice, _ := st.CreateUser(ctx, store.UserInput{Username: "alice", Role: "user", PasswordHash: ptr("h")})
+	bob, _ := st.CreateUser(ctx, store.UserInput{Username: "bob", Role: "user", PasswordHash: ptr("h")})
+	task, err := st.CreateTask(ctx, alice.ID, store.TaskInput{Name: "Shared chore"})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	s := NewServer(st, Options{})
+	h := s.Handler()
+	return shareTestEnv{
+		st:     st,
+		h:      h,
+		alice:  alice,
+		bob:    bob,
+		taskID: task.ID,
+		cookie: map[int64]*http.Cookie{
+			alice.ID: signIn(t, st, s.opts.SessionTTL, alice),
+			bob.ID:   signIn(t, st, s.opts.SessionTTL, bob),
+		},
+	}
+}
+
+func (e shareTestEnv) do(t *testing.T, as store.User, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, r)
+	req.AddCookie(e.cookie[as.ID])
+	w := httptest.NewRecorder()
+	e.h.ServeHTTP(w, req)
+	return w
+}
+
+// taskIDs lists the task ids the given user sees via GET /api/tasks.
+func (e shareTestEnv) taskIDs(t *testing.T, as store.User) []int64 {
+	t.Helper()
+	w := e.do(t, as, http.MethodGet, "/api/tasks", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/tasks = %d", w.Code)
+	}
+	var tasks []store.Task
+	if err := json.Unmarshal(w.Body.Bytes(), &tasks); err != nil {
+		t.Fatalf("decode tasks: %v", err)
+	}
+	ids := make([]int64, len(tasks))
+	for i, tk := range tasks {
+		ids[i] = tk.ID
+	}
+	return ids
+}
+
+func containsID(ids []int64, id int64) bool {
+	for _, v := range ids {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestShareFlowHTTP(t *testing.T) {
+	e := newShareEnv(t, true)
+	share := "/api/tasks/" + itoa(e.taskID)
+
+	// Alice shares with bob.
+	if w := e.do(t, e.alice, http.MethodPost, share+"/share", `{"username":"bob"}`); w.Code != http.StatusCreated {
+		t.Fatalf("share = %d, want 201 (body: %s)", w.Code, w.Body.String())
+	}
+	// Pending: not yet in bob's task list, but present in his requests.
+	if containsID(e.taskIDs(t, e.bob), e.taskID) {
+		t.Fatal("pending share should not appear in bob's tasks")
+	}
+	w := e.do(t, e.bob, http.MethodGet, "/api/me/shares", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/me/shares = %d", w.Code)
+	}
+	var reqs []store.ShareRequest
+	if err := json.Unmarshal(w.Body.Bytes(), &reqs); err != nil {
+		t.Fatalf("decode requests: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].TaskID != e.taskID || reqs[0].OwnerName != "alice" {
+		t.Fatalf("unexpected requests: %+v", reqs)
+	}
+
+	// Bob accepts; now it's in his task list and his requests are empty.
+	if w := e.do(t, e.bob, http.MethodPost, share+"/share/respond", `{"accept":true}`); w.Code != http.StatusNoContent {
+		t.Fatalf("respond accept = %d, want 204 (body: %s)", w.Code, w.Body.String())
+	}
+	if !containsID(e.taskIDs(t, e.bob), e.taskID) {
+		t.Fatal("accepted share should appear in bob's tasks")
+	}
+	if w := e.do(t, e.bob, http.MethodGet, "/api/me/shares", ""); !strings.Contains(w.Body.String(), "[]") {
+		t.Fatalf("requests should be empty after accept, got %s", w.Body.String())
+	}
+
+	// Members endpoint (visible to bob): owner alice + accepted bob.
+	w = e.do(t, e.bob, http.MethodGet, share+"/members", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET members = %d", w.Code)
+	}
+	var members []store.TaskMember
+	if err := json.Unmarshal(w.Body.Bytes(), &members); err != nil {
+		t.Fatalf("decode members: %v", err)
+	}
+	if len(members) != 2 || members[0].Status != "owner" || members[0].Username != "alice" ||
+		members[1].Username != "bob" || members[1].Status != "accepted" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+}
+
+func TestShareGateOff(t *testing.T) {
+	e := newShareEnv(t, false) // tasks_shareable defaults off
+	w := e.do(t, e.alice, http.MethodPost, "/api/tasks/"+itoa(e.taskID)+"/share", `{"username":"bob"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("share with feature off = %d, want 403", w.Code)
+	}
+}
+
+func TestShareValidationHTTP(t *testing.T) {
+	e := newShareEnv(t, true)
+	share := "/api/tasks/" + itoa(e.taskID) + "/share"
+
+	cases := []struct {
+		name, body string
+		actor      store.User
+		want       int
+	}{
+		{"unknown user", `{"username":"nobody"}`, e.alice, http.StatusNotFound},
+		{"self", `{"username":"alice"}`, e.alice, http.StatusBadRequest},
+		{"non-owner", `{"username":"alice"}`, e.bob, http.StatusNotFound},
+		{"empty username", `{"username":"  "}`, e.alice, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if w := e.do(t, tc.actor, http.MethodPost, share, tc.body); w.Code != tc.want {
+				t.Fatalf("%s = %d, want %d (body: %s)", tc.name, w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+
+	// First share succeeds, a duplicate conflicts.
+	if w := e.do(t, e.alice, http.MethodPost, share, `{"username":"bob"}`); w.Code != http.StatusCreated {
+		t.Fatalf("first share = %d, want 201", w.Code)
+	}
+	if w := e.do(t, e.alice, http.MethodPost, share, `{"username":"bob"}`); w.Code != http.StatusConflict {
+		t.Fatalf("duplicate share = %d, want 409", w.Code)
+	}
+}
+
+func TestAllowSharesOptOutHTTP(t *testing.T) {
+	e := newShareEnv(t, true)
+
+	// Bob opts out; /api/auth/me reflects it.
+	if w := e.do(t, e.bob, http.MethodPut, "/api/me/allow-shares", `{"allowShares":false}`); w.Code != http.StatusOK {
+		t.Fatalf("set allow-shares = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	w := e.do(t, e.bob, http.MethodGet, "/api/auth/me", "")
+	var me store.User
+	if err := json.Unmarshal(w.Body.Bytes(), &me); err != nil {
+		t.Fatalf("decode me: %v", err)
+	}
+	if me.AllowShares {
+		t.Fatal("bob should read AllowShares=false after opting out")
+	}
+
+	// Alice can no longer share with bob.
+	if w := e.do(t, e.alice, http.MethodPost, "/api/tasks/"+itoa(e.taskID)+"/share", `{"username":"bob"}`); w.Code != http.StatusForbidden {
+		t.Fatalf("share to opted-out user = %d, want 403", w.Code)
+	}
+}
+
+func TestLeaveHTTP(t *testing.T) {
+	e := newShareEnv(t, true)
+	base := "/api/tasks/" + itoa(e.taskID)
+	if w := e.do(t, e.alice, http.MethodPost, base+"/share", `{"username":"bob"}`); w.Code != http.StatusCreated {
+		t.Fatalf("share = %d", w.Code)
+	}
+	if w := e.do(t, e.bob, http.MethodPost, base+"/share/respond", `{"accept":true}`); w.Code != http.StatusNoContent {
+		t.Fatalf("accept = %d", w.Code)
+	}
+	// Bob leaves; the task drops from his list but stays in alice's.
+	if w := e.do(t, e.bob, http.MethodPost, base+"/leave", ""); w.Code != http.StatusNoContent {
+		t.Fatalf("leave = %d, want 204 (body: %s)", w.Code, w.Body.String())
+	}
+	if containsID(e.taskIDs(t, e.bob), e.taskID) {
+		t.Fatal("task should be gone from bob after leaving")
+	}
+	if !containsID(e.taskIDs(t, e.alice), e.taskID) {
+		t.Fatal("task should remain with alice after bob leaves")
+	}
+	// Leaving again is a 404.
+	if w := e.do(t, e.bob, http.MethodPost, base+"/leave", ""); w.Code != http.StatusNotFound {
+		t.Fatalf("leave twice = %d, want 404", w.Code)
+	}
+}
+
+// itoa is a tiny local int64->string to keep paths readable.
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/api/tags_test.go
+++ b/internal/api/tags_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeTags(t *testing.T) {
+	// Trims, drops empties, and de-duplicates case-insensitively (first wins).
+	got, msg := normalizeTags([]string{" home ", "Home", "", "plants", "PLANTS"})
+	if msg != "" {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if !reflect.DeepEqual(got, []string{"home", "plants"}) {
+		t.Fatalf("normalizeTags = %#v", got)
+	}
+
+	if _, msg := normalizeTags([]string{strings.Repeat("a", maxTagLen+1)}); msg == "" {
+		t.Fatal("expected an error for an over-long tag")
+	}
+
+	many := make([]string, maxTags+1)
+	for i := range many {
+		many[i] = string(rune('a' + i))
+	}
+	if _, msg := normalizeTags(many); msg == "" {
+		t.Fatal("expected an error for too many tags")
+	}
+}

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// updateCacheTTL caps how often the upstream version is fetched.
+const updateCacheTTL = 30 * time.Minute
+
+var errUpstream = errors.New("update check upstream returned a non-200 status")
+
+// handleCheckVersion reports the latest released version, fetched server-side
+// from UpdateCheckURL (the browser can't reach it directly under the CSP). It is
+// purely informational — there is no in-app update action. Returns
+// {"latest": "x.y.z"}; "" when checking is disabled or the upstream is
+// unreachable.
+func (s *Server) handleCheckVersion(w http.ResponseWriter, r *http.Request) {
+	// Admin-only: upgrades are an operator concern, and this matches the UI,
+	// which shows the "Check for updates" button to admins only.
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+	url := s.opts.UpdateCheckURL
+	if strings.TrimSpace(url) == "" {
+		writeJSON(w, http.StatusOK, map[string]string{"latest": ""})
+		return
+	}
+
+	s.updateMu.Lock()
+	cached := s.updateVer
+	fresh := time.Since(s.updateAt) < updateCacheTTL && s.updateVer != ""
+	s.updateMu.Unlock()
+	if fresh {
+		writeJSON(w, http.StatusOK, map[string]string{"latest": cached})
+		return
+	}
+
+	latest, err := fetchLatestVersion(r.Context(), url)
+	if err != nil {
+		// Don't fail the UI hard: report "unknown" rather than an error code.
+		writeJSON(w, http.StatusOK, map[string]string{"latest": ""})
+		return
+	}
+
+	s.updateMu.Lock()
+	s.updateVer = latest
+	s.updateAt = time.Now()
+	s.updateMu.Unlock()
+	writeJSON(w, http.StatusOK, map[string]string{"latest": latest})
+}
+
+// fetchLatestVersion GETs the upstream JSON and returns its "version" field.
+func fetchLatestVersion(ctx context.Context, url string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", errUpstream
+	}
+	// Cap the body; the upstream is a small package.json.
+	var payload struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(payload.Version), nil
+}

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/unmaykr-a/taskrr/internal/store"
+)
+
+func TestVersionLatestIsAdminOnly(t *testing.T) {
+	ctx := context.Background()
+	st := openStore(t)
+	admin, _ := st.CreateUser(ctx, store.UserInput{Username: "admin", Role: "admin", PasswordHash: ptr("h")})
+	user, _ := st.CreateUser(ctx, store.UserInput{Username: "user", Role: "user", PasswordHash: ptr("h")})
+	s := NewServer(st, Options{}) // UpdateCheckURL empty -> no network, returns latest ""
+	h := s.Handler()
+
+	get := func(u store.User) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/version/latest", nil)
+		req.AddCookie(signIn(t, st, s.opts.SessionTTL, u))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := get(user); code != http.StatusForbidden {
+		t.Fatalf("non-admin /api/version/latest = %d, want 403", code)
+	}
+	if code := get(admin); code != http.StatusOK {
+		t.Fatalf("admin /api/version/latest = %d, want 200", code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,12 @@ type Config struct {
 	// safety snapshots on every restore.
 	SafetyBackupOnRestore bool
 
+	// UpdateCheckURL is fetched (server-side) to report the latest released
+	// version in the changelog menu. It should return JSON with a "version"
+	// field; the default points at the project's package.json on GitHub. Set it
+	// empty to disable the check entirely.
+	UpdateCheckURL string
+
 	// --- OIDC (Phase 2; initial values, overridable later in the admin UI) ---
 	OIDCIssuer       string
 	OIDCClientID     string
@@ -93,6 +99,8 @@ func Load() Config {
 		Lite:              envBool("TASKRR_LITE", false),
 
 		SafetyBackupOnRestore: envBool("TASKRR_SAFETY_BACKUP", true),
+		UpdateCheckURL: envAllowEmpty("TASKRR_UPDATE_CHECK_URL",
+			"https://raw.githubusercontent.com/unmaykr-a/taskrr/main/web/package.json"),
 
 		OIDCIssuer:       env("TASKRR_OIDC_ISSUER", ""),
 		OIDCClientID:     env("TASKRR_OIDC_CLIENT_ID", ""),
@@ -104,6 +112,16 @@ func Load() Config {
 // env returns the value of key, or def if the variable is unset or empty.
 func env(key, def string) string {
 	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+// envAllowEmpty returns the value whenever the key is set (even to ""), so an
+// explicit empty value is meaningful (e.g. disabling a feature); the default
+// applies only when the key is absent.
+func envAllowEmpty(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok {
 		return v
 	}
 	return def

--- a/internal/store/account_transfer_test.go
+++ b/internal/store/account_transfer_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// shareAndAccept shares taskID from owner to member and accepts it.
+func shareAndAccept(t *testing.T, st *Store, owner, member, taskID int64) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := st.ShareTask(ctx, owner, taskID, member); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, member, taskID, true); err != nil {
+		t.Fatalf("RespondToShare: %v", err)
+	}
+}
+
+func TestDeleteUserTransfersSharedTasks(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	shared := makeTask(t, st, alice, "shared")
+	solo := makeTask(t, st, alice, "solo")
+	shareAndAccept(t, st, alice, bob, shared)
+	if _, err := st.AddCompletion(ctx, alice, shared, time.Now(), "alice logged"); err != nil {
+		t.Fatalf("AddCompletion: %v", err)
+	}
+
+	// Deleting alice's account transfers the shared task to bob and removes solo.
+	if err := st.DeleteUser(ctx, alice); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	got, err := st.GetTask(ctx, bob, shared)
+	if err != nil {
+		t.Fatalf("GetTask(bob, shared) after owner delete: %v", err)
+	}
+	if got.OwnerID != bob {
+		t.Fatalf("shared task owner = %d, want bob (%d)", got.OwnerID, bob)
+	}
+	if got.CompletionCount != 1 {
+		t.Fatalf("history lost on transfer: completionCount = %d", got.CompletionCount)
+	}
+	// The departed owner's completion survives, now attributed to nobody.
+	cs, err := st.ListCompletions(ctx, bob, shared)
+	if err != nil {
+		t.Fatalf("ListCompletions: %v", err)
+	}
+	if len(cs) != 1 || cs[0].UserID != nil {
+		t.Fatalf("expected one orphan-authored completion, got %+v", cs)
+	}
+	// Bob is no longer a member (he's the owner); no stray share row.
+	members, _ := st.ListTaskMembers(ctx, shared)
+	if len(members) != 1 || members[0].Status != "owner" || members[0].UserID != bob {
+		t.Fatalf("unexpected members after transfer: %+v", members)
+	}
+	// The solo task was cascaded away with the account.
+	if _, err := st.GetTask(ctx, bob, solo); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("solo task should be gone, GetTask = %v", err)
+	}
+}
+
+func TestWipeMyDataTransfersSharedTasks(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	shared := makeTask(t, st, alice, "shared")
+	_ = makeTask(t, st, alice, "solo")
+	shareAndAccept(t, st, alice, bob, shared)
+
+	// Wiping alice's data deletes only her solo task; the shared one moves to bob.
+	n, err := st.DeleteTasksByOwner(ctx, alice)
+	if err != nil {
+		t.Fatalf("DeleteTasksByOwner: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted count = %d, want 1 (solo only)", n)
+	}
+	if got, err := st.GetTask(ctx, bob, shared); err != nil || got.OwnerID != bob {
+		t.Fatalf("shared task should belong to bob now: task=%+v err=%v", got, err)
+	}
+	if visible(t, st, alice, shared) {
+		t.Fatal("alice should no longer see the task she left by wiping data")
+	}
+}
+
+func TestMergeWithoutMoveDataTransfersShared(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	carol := makeUser(t, st, "carol") // merge target
+	shared := makeTask(t, st, alice, "shared")
+	shareAndAccept(t, st, alice, bob, shared)
+
+	// Fold alice into carol without moving data: alice's shared task goes to its
+	// member (bob), not to carol.
+	if err := st.MergeUsers(ctx, alice, carol, false, ""); err != nil {
+		t.Fatalf("MergeUsers: %v", err)
+	}
+	if got, err := st.GetTask(ctx, bob, shared); err != nil || got.OwnerID != bob {
+		t.Fatalf("shared task should transfer to bob: task=%+v err=%v", got, err)
+	}
+	if visible(t, st, carol, shared) {
+		t.Fatal("carol should not receive the task in a no-move merge")
+	}
+}
+
+func TestMergeWithMoveDataReassignsAndDedups(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	carol := makeUser(t, st, "carol") // merge target, already a member
+	shared := makeTask(t, st, alice, "shared")
+	shareAndAccept(t, st, alice, carol, shared)
+	if _, err := st.AddCompletion(ctx, alice, shared, time.Now(), "alice logged"); err != nil {
+		t.Fatalf("AddCompletion: %v", err)
+	}
+
+	// Fold alice into carol, moving data: carol owns the task, the redundant
+	// membership row is gone, and alice's completion authorship becomes carol's.
+	if err := st.MergeUsers(ctx, alice, carol, true, ""); err != nil {
+		t.Fatalf("MergeUsers: %v", err)
+	}
+	got, err := st.GetTask(ctx, carol, shared)
+	if err != nil || got.OwnerID != carol {
+		t.Fatalf("carol should own the task after move-merge: task=%+v err=%v", got, err)
+	}
+	members, _ := st.ListTaskMembers(ctx, shared)
+	if len(members) != 1 || members[0].Status != "owner" || members[0].UserID != carol {
+		t.Fatalf("owner should not also be a member after merge: %+v", members)
+	}
+	cs, err := st.ListCompletions(ctx, carol, shared)
+	if err != nil {
+		t.Fatalf("ListCompletions: %v", err)
+	}
+	if len(cs) != 1 || cs[0].UserID == nil || *cs[0].UserID != carol {
+		t.Fatalf("completion authorship should fold into carol, got %+v", cs)
+	}
+}

--- a/internal/store/completions.go
+++ b/internal/store/completions.go
@@ -2,35 +2,41 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"time"
 )
 
-// ownsTask reports whether ownerID owns the given task.
-func (s *Store) ownsTask(ctx context.Context, ownerID, taskID int64) (bool, error) {
+// canAccessTask reports whether userID may see/log the task — i.e. they own it
+// or have an accepted share. (Replaces the old owner-only check now that tasks
+// can be shared.)
+func (s *Store) canAccessTask(ctx context.Context, userID, taskID int64) (bool, error) {
 	var n int
 	if err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM tasks WHERE id = ? AND owner_id = ?`, taskID, ownerID,
+		`SELECT COUNT(*) FROM tasks t WHERE t.id = ? AND `+visibleTaskCond,
+		taskID, userID, userID,
 	).Scan(&n); err != nil {
 		return false, err
 	}
 	return n > 0, nil
 }
 
-// AddCompletion logs that a task was done at completedAt with an optional note.
-// Returns ErrNotFound if the task does not exist or isn't owned by ownerID.
-func (s *Store) AddCompletion(ctx context.Context, ownerID, taskID int64, completedAt time.Time, note string) (Completion, error) {
-	owns, err := s.ownsTask(ctx, ownerID, taskID)
+// AddCompletion logs that a task was done at completedAt with an optional note,
+// recording userID as the actor ("who logged it"). Returns ErrNotFound if the
+// task does not exist or isn't visible to userID (owner or accepted member).
+func (s *Store) AddCompletion(ctx context.Context, userID, taskID int64, completedAt time.Time, note string) (Completion, error) {
+	access, err := s.canAccessTask(ctx, userID, taskID)
 	if err != nil {
 		return Completion{}, err
 	}
-	if !owns {
+	if !access {
 		return Completion{}, ErrNotFound
 	}
 
 	now := time.Now().UTC()
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO completions (task_id, completed_at, note, created_at) VALUES (?, ?, ?, ?)`,
-		taskID, completedAt.UTC().Format(timeLayout), note, now.Format(timeLayout),
+		`INSERT INTO completions (task_id, user_id, completed_at, note, created_at) VALUES (?, ?, ?, ?, ?)`,
+		taskID, userID, completedAt.UTC().Format(timeLayout), note, now.Format(timeLayout),
 	)
 	if err != nil {
 		return Completion{}, err
@@ -39,24 +45,26 @@ func (s *Store) AddCompletion(ctx context.Context, ownerID, taskID int64, comple
 	if err != nil {
 		return Completion{}, err
 	}
+	actor := userID
 	return Completion{
 		ID:          id,
 		TaskID:      taskID,
+		UserID:      &actor,
 		CompletedAt: completedAt.UTC(),
 		Note:        note,
 		CreatedAt:   now,
 	}, nil
 }
 
-// ListCompletions returns a task's completions (most recent first), scoped to
-// the owner so one user can't read another's history.
-func (s *Store) ListCompletions(ctx context.Context, ownerID, taskID int64) ([]Completion, error) {
+// ListCompletions returns a task's completions (most recent first), visible to
+// userID (owner or accepted member) so collaborators share one history.
+func (s *Store) ListCompletions(ctx context.Context, userID, taskID int64) ([]Completion, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT c.id, c.task_id, c.completed_at, c.note, c.created_at
+		`SELECT c.id, c.task_id, c.user_id, c.completed_at, c.note, c.created_at
 		 FROM completions c
 		 JOIN tasks t ON t.id = c.task_id
-		 WHERE c.task_id = ? AND t.owner_id = ?
-		 ORDER BY c.completed_at DESC, c.id DESC`, taskID, ownerID)
+		 WHERE c.task_id = ? AND `+visibleTaskCond+`
+		 ORDER BY c.completed_at DESC, c.id DESC`, taskID, userID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -64,32 +72,26 @@ func (s *Store) ListCompletions(ctx context.Context, ownerID, taskID int64) ([]C
 
 	out := make([]Completion, 0)
 	for rows.Next() {
-		var (
-			c         Completion
-			completed string
-			created   string
-		)
-		if err := rows.Scan(&c.ID, &c.TaskID, &completed, &c.Note, &created); err != nil {
+		c, err := scanCompletion(rows)
+		if err != nil {
 			return nil, err
 		}
-		c.CompletedAt = parseTime(completed)
-		c.CreatedAt = parseTime(created)
 		out = append(out, c)
 	}
 	return out, rows.Err()
 }
 
-// ListActivity returns every completion (across the owner's tasks) whose
-// completed_at falls within [from, to), joined with the task name. This is the
-// flat feed the calendar renders.
-func (s *Store) ListActivity(ctx context.Context, ownerID int64, from, to time.Time) ([]Activity, error) {
+// ListActivity returns every completion across the tasks visible to userID
+// (owned or shared+accepted) whose completed_at falls within [from, to), joined
+// with the task name. This is the flat feed the calendar renders.
+func (s *Store) ListActivity(ctx context.Context, userID int64, from, to time.Time) ([]Activity, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT c.id, c.task_id, t.name, c.completed_at, c.note
 		 FROM completions c
 		 JOIN tasks t ON t.id = c.task_id
-		 WHERE t.owner_id = ? AND c.completed_at >= ? AND c.completed_at < ?
+		 WHERE `+visibleTaskCond+` AND c.completed_at >= ? AND c.completed_at < ?
 		 ORDER BY c.completed_at DESC, c.id DESC`,
-		ownerID, from.UTC().Format(timeLayout), to.UTC().Format(timeLayout),
+		userID, userID, from.UTC().Format(timeLayout), to.UTC().Format(timeLayout),
 	)
 	if err != nil {
 		return nil, err
@@ -111,45 +113,90 @@ func (s *Store) ListActivity(ctx context.Context, ownerID int64, from, to time.T
 	return out, rows.Err()
 }
 
-// UpdateCompletion edits a single completion's time and/or note (owner-scoped).
-func (s *Store) UpdateCompletion(ctx context.Context, ownerID, id int64, completedAt time.Time, note string) (Completion, error) {
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE completions SET completed_at = ?, note = ?
-		 WHERE id = ? AND task_id IN (SELECT id FROM tasks WHERE owner_id = ?)`,
-		completedAt.UTC().Format(timeLayout), note, id, ownerID,
-	)
+// UpdateCompletion edits a single completion's time and/or note. Permitted for
+// the task's owner (any entry) or the entry's own author (while they still have
+// access); otherwise ErrNotFound.
+func (s *Store) UpdateCompletion(ctx context.Context, userID, id int64, completedAt time.Time, note string) (Completion, error) {
+	allowed, err := s.canModifyCompletion(ctx, userID, id)
 	if err != nil {
 		return Completion{}, err
 	}
-	if n, _ := res.RowsAffected(); n == 0 {
+	if !allowed {
 		return Completion{}, ErrNotFound
 	}
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE completions SET completed_at = ?, note = ? WHERE id = ?`,
+		completedAt.UTC().Format(timeLayout), note, id,
+	); err != nil {
+		return Completion{}, err
+	}
+	c, err := scanCompletion(s.db.QueryRowContext(ctx,
+		`SELECT id, task_id, user_id, completed_at, note, created_at FROM completions WHERE id = ?`, id))
+	if err != nil {
+		return Completion{}, err
+	}
+	return c, nil
+}
+
+// DeleteCompletion removes a single completion entry (an "undo"). Permitted for
+// the task's owner (any entry) or the entry's own author; otherwise ErrNotFound.
+func (s *Store) DeleteCompletion(ctx context.Context, userID, id int64) error {
+	allowed, err := s.canModifyCompletion(ctx, userID, id)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrNotFound
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM completions WHERE id = ?`, id)
+	return err
+}
+
+// canModifyCompletion reports whether userID may edit/delete the given
+// completion: true for the task owner, or for the entry's author while they
+// still have access to the task. A missing completion yields (false, nil) so
+// callers map it to ErrNotFound.
+func (s *Store) canModifyCompletion(ctx context.Context, userID, completionID int64) (bool, error) {
+	var (
+		taskID int64
+		author sql.NullInt64
+		owner  int64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT c.task_id, c.user_id, t.owner_id
+		 FROM completions c JOIN tasks t ON t.id = c.task_id
+		 WHERE c.id = ?`, completionID).Scan(&taskID, &author, &owner)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if owner == userID {
+		return true, nil
+	}
+	if author.Valid && author.Int64 == userID {
+		return s.canAccessTask(ctx, userID, taskID)
+	}
+	return false, nil
+}
+
+// scanCompletion reads a completion row in the (id, task_id, user_id,
+// completed_at, note, created_at) projection.
+func scanCompletion(sc scanner) (Completion, error) {
 	var (
 		c         Completion
+		userID    sql.NullInt64
 		completed string
 		created   string
 	)
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT id, task_id, completed_at, note, created_at FROM completions WHERE id = ?`, id,
-	).Scan(&c.ID, &c.TaskID, &completed, &c.Note, &created); err != nil {
+	if err := sc.Scan(&c.ID, &c.TaskID, &userID, &completed, &c.Note, &created); err != nil {
 		return Completion{}, err
+	}
+	if userID.Valid {
+		c.UserID = &userID.Int64
 	}
 	c.CompletedAt = parseTime(completed)
 	c.CreatedAt = parseTime(created)
 	return c, nil
-}
-
-// DeleteCompletion removes a single completion entry (an "undo"), owner-scoped.
-func (s *Store) DeleteCompletion(ctx context.Context, ownerID, id int64) error {
-	res, err := s.db.ExecContext(ctx,
-		`DELETE FROM completions WHERE id = ? AND task_id IN (SELECT id FROM tasks WHERE owner_id = ?)`,
-		id, ownerID,
-	)
-	if err != nil {
-		return err
-	}
-	if n, _ := res.RowsAffected(); n == 0 {
-		return ErrNotFound
-	}
-	return nil
 }

--- a/internal/store/migrations/0010_task_shares.sql
+++ b/internal/store/migrations/0010_task_shares.sql
@@ -1,0 +1,36 @@
+-- Shared tasks: a task is shared by attaching additional members to it, while
+-- it stays a single row owned by tasks.owner_id. Members are rows in
+-- task_shares; there are no copies to keep in sync.
+--
+-- This model makes the delete semantics fall out naturally: a member leaving is
+-- just deleting their share row, and the task plus its history persist for
+-- whoever remains. When the owner "deletes" a task that still has accepted
+-- members, ownership transfers to the earliest member instead of destroying it
+-- (handled in the application layer); only a task with no members is truly
+-- removed.
+
+CREATE TABLE task_shares (
+    task_id    INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- 'pending'  = an invitation awaiting the recipient's response (their Requests)
+    -- 'accepted' = an active member who sees and can log the task
+    status     TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (task_id, user_id)
+);
+-- Listing a user's incoming requests / their shared tasks both filter by user.
+CREATE INDEX idx_task_shares_user ON task_shares (user_id, status);
+
+-- Who logged each completion. Nullable so the column adds cleanly to an existing
+-- DB; backfilled to the task's owner so all prior history reads as "the owner did
+-- it". New completions record the acting user. ON DELETE SET NULL keeps a shared
+-- task's history intact when a member account is removed (the entry remains,
+-- attributed to nobody) rather than cascading the row away.
+ALTER TABLE completions ADD COLUMN user_id INTEGER REFERENCES users(id) ON DELETE SET NULL;
+UPDATE completions
+   SET user_id = (SELECT owner_id FROM tasks WHERE tasks.id = completions.task_id)
+ WHERE user_id IS NULL;
+
+-- Per-user opt-out. When 0, the share API refuses to create a share targeting
+-- this user, so opting out is enforced server-side rather than just hidden.
+ALTER TABLE users ADD COLUMN allow_shares INTEGER NOT NULL DEFAULT 1;

--- a/internal/store/migrations/0011_task_tags.sql
+++ b/internal/store/migrations/0011_task_tags.sql
@@ -1,0 +1,3 @@
+-- Per-task tags: a JSON array of short labels, used for filtering and grouping
+-- in the UI. Stored as text so it adds cleanly to an existing DB.
+ALTER TABLE tasks ADD COLUMN tags TEXT NOT NULL DEFAULT '[]';

--- a/internal/store/migrations/0012_task_folder.sql
+++ b/internal/store/migrations/0012_task_folder.sql
@@ -1,0 +1,3 @@
+-- Per-task folder: a single optional group name used to organise the task list
+-- into collapsible sections. Empty means ungrouped.
+ALTER TABLE tasks ADD COLUMN folder TEXT NOT NULL DEFAULT '';

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -20,14 +20,28 @@ type Task struct {
 	// FreezeColor pins the staleness colour to the "fresh" end (a purely visual
 	// "stay green" preference; cadence/due/filters are unaffected).
 	FreezeColor bool `json:"freezeColor"`
+	// Tags are short user labels for filtering and grouping.
+	Tags []string `json:"tags"`
+	// Folder is an optional single group name; empty means ungrouped.
+	Folder string `json:"folder"`
 	// ArchivedAt is non-nil when the task has been soft-archived (hidden from the
 	// normal views but kept, with its history, so it can be restored).
 	ArchivedAt *time.Time `json:"archivedAt"`
 	CreatedAt  time.Time  `json:"createdAt"`
 	UpdatedAt  time.Time  `json:"updatedAt"`
+	// OwnerID is the account that owns the task. With shared tasks a viewer may
+	// be an accepted member rather than the owner, so the API/UI can compare this
+	// to the current user to decide who may edit/archive the definition.
+	OwnerID int64 `json:"ownerId"`
 	// Derived fields (not stored on the row; computed from the completions log).
 	LastCompletedAt *time.Time `json:"lastCompletedAt"`
 	CompletionCount int        `json:"completionCount"`
+	// Shared is true when the task has any members (shared by the owner, or
+	// shared with the viewer). Lets the UI flag and group shared tasks.
+	Shared bool `json:"shared"`
+	// LastCompletedBy is the username of whoever logged the most recent
+	// completion (nil if none, or that author's account was removed).
+	LastCompletedBy *string `json:"lastCompletedBy"`
 }
 
 // TaskInput carries the user-editable fields of a task. It is shared by Create
@@ -40,12 +54,17 @@ type TaskInput struct {
 	ColorFresh      *string // nil clears the override (use the default)
 	ColorOverdue    *string // nil clears the override (use the default)
 	FreezeColor     bool    // pin the staleness colour to "fresh"
+	Tags            []string
+	Folder          string
 }
 
 // Completion is a single logged occurrence of a task being done.
 type Completion struct {
-	ID          int64     `json:"id"`
-	TaskID      int64     `json:"taskId"`
+	ID     int64 `json:"id"`
+	TaskID int64 `json:"taskId"`
+	// UserID is who logged this completion (nil only for orphaned history whose
+	// author account was removed). On a shared task this drives "last logged by".
+	UserID      *int64    `json:"userId"`
 	CompletedAt time.Time `json:"completedAt"`
 	Note        string    `json:"note"`
 	CreatedAt   time.Time `json:"createdAt"`

--- a/internal/store/shares.go
+++ b/internal/store/shares.go
@@ -1,0 +1,255 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// Share-specific sentinel errors. The API layer maps these to user-facing
+// messages (and an appropriate status code) in a later phase.
+var (
+	// ErrShareNotAllowed is returned when the recipient has opted out of shares.
+	ErrShareNotAllowed = errors.New("recipient does not accept shared tasks")
+	// ErrAlreadyShared is returned when a share to that user already exists.
+	ErrAlreadyShared = errors.New("task is already shared with that user")
+	// ErrShareSelf is returned when a user tries to share a task with themselves.
+	ErrShareSelf = errors.New("cannot share a task with yourself")
+)
+
+// reassignSharedTasks transfers every task owned by userID that still has an
+// accepted member to the earliest such member (dropping that member's share
+// row), within the caller's transaction. So removing a user — account deletion,
+// wipe-my-data, or a non-moving merge — never destroys a task other members
+// rely on; only their solo tasks are left for the caller's delete/cascade.
+// Mirrors the owner-delete transfer in DeleteTask.
+func reassignSharedTasks(ctx context.Context, tx *sql.Tx, userID int64) error {
+	// Materialise the transfers first: SQLite on a single connection can't run
+	// the UPDATEs while this query's rows are still open.
+	rows, err := tx.QueryContext(ctx,
+		`SELECT t.id,
+		        (SELECT s.user_id FROM task_shares s
+		          WHERE s.task_id = t.id AND s.status = 'accepted'
+		          ORDER BY s.created_at ASC, s.user_id ASC LIMIT 1)
+		   FROM tasks t
+		  WHERE t.owner_id = ?
+		    AND EXISTS (SELECT 1 FROM task_shares s
+		                 WHERE s.task_id = t.id AND s.status = 'accepted')`, userID)
+	if err != nil {
+		return err
+	}
+	type transfer struct{ taskID, newOwner int64 }
+	var transfers []transfer
+	for rows.Next() {
+		var tr transfer
+		if err := rows.Scan(&tr.taskID, &tr.newOwner); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		transfers = append(transfers, tr)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	_ = rows.Close()
+
+	now := time.Now().UTC().Format(timeLayout)
+	for _, tr := range transfers {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE tasks SET owner_id = ?, updated_at = ? WHERE id = ?`, tr.newOwner, now, tr.taskID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM task_shares WHERE task_id = ? AND user_id = ?`, tr.taskID, tr.newOwner); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TaskShare struct {
+	TaskID    int64     `json:"taskId"`
+	UserID    int64     `json:"userId"`
+	Status    string    `json:"status"` // "pending" | "accepted"
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// ShareRequest is a pending incoming share, with the task and owner named, as
+// shown in the recipient's Requests view.
+type ShareRequest struct {
+	TaskID    int64     `json:"taskId"`
+	TaskName  string    `json:"taskName"`
+	OwnerID   int64     `json:"ownerId"`
+	OwnerName string    `json:"ownerName"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// TaskMember is one participant in a task: the owner, or a shared member with
+// their status. Used to badge shared tasks with their collaborators.
+type TaskMember struct {
+	UserID   int64  `json:"userId"`
+	Username string `json:"username"`
+	// Status is "owner" for the task's owner, else the share status
+	// ("pending" | "accepted").
+	Status string `json:"status"`
+}
+
+// ShareTask invites recipientID to a task owned by ownerID, creating a pending
+// share. Only the owner may share. Errors: ErrNotFound (no such task owned by
+// ownerID, or no such recipient), ErrShareSelf, ErrShareNotAllowed (recipient
+// opted out), ErrAlreadyShared.
+func (s *Store) ShareTask(ctx context.Context, ownerID, taskID, recipientID int64) (TaskShare, error) {
+	if recipientID == ownerID {
+		return TaskShare{}, ErrShareSelf
+	}
+
+	// The task must exist and be owned by the sharer.
+	var owner int64
+	switch err := s.db.QueryRowContext(ctx, `SELECT owner_id FROM tasks WHERE id = ?`, taskID).Scan(&owner); {
+	case errors.Is(err, sql.ErrNoRows):
+		return TaskShare{}, ErrNotFound
+	case err != nil:
+		return TaskShare{}, err
+	}
+	if owner != ownerID {
+		return TaskShare{}, ErrNotFound // a non-owner can't share
+	}
+
+	// The recipient must exist and accept shares.
+	allow, err := s.GetUserAllowShares(ctx, recipientID)
+	if err != nil {
+		return TaskShare{}, err // ErrNotFound for a missing user
+	}
+	if !allow {
+		return TaskShare{}, ErrShareNotAllowed
+	}
+
+	// Reject a duplicate up front (the (task_id, user_id) primary key would also
+	// reject it, but this yields the typed ErrAlreadyShared the API wants).
+	var existing int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM task_shares WHERE task_id = ? AND user_id = ?`,
+		taskID, recipientID).Scan(&existing); err != nil {
+		return TaskShare{}, err
+	}
+	if existing > 0 {
+		return TaskShare{}, ErrAlreadyShared
+	}
+
+	now := time.Now().UTC()
+	if _, err = s.db.ExecContext(ctx,
+		`INSERT INTO task_shares (task_id, user_id, status, created_at) VALUES (?, ?, 'pending', ?)`,
+		taskID, recipientID, now.Format(timeLayout),
+	); err != nil {
+		return TaskShare{}, err
+	}
+	return TaskShare{TaskID: taskID, UserID: recipientID, Status: "pending", CreatedAt: now}, nil
+}
+
+// RespondToShare accepts or declines a pending incoming share for userID.
+// Accepting flips it to 'accepted'; declining removes the row (leaving the task
+// solely the owner's). ErrNotFound if there is no pending share for that user.
+func (s *Store) RespondToShare(ctx context.Context, userID, taskID int64, accept bool) error {
+	var (
+		res sql.Result
+		err error
+	)
+	if accept {
+		res, err = s.db.ExecContext(ctx,
+			`UPDATE task_shares SET status = 'accepted' WHERE task_id = ? AND user_id = ? AND status = 'pending'`,
+			taskID, userID)
+	} else {
+		res, err = s.db.ExecContext(ctx,
+			`DELETE FROM task_shares WHERE task_id = ? AND user_id = ? AND status = 'pending'`,
+			taskID, userID)
+	}
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// LeaveTask removes userID's membership of a task (accepted or still pending).
+// The task and its history persist for the owner and any other members.
+// ErrNotFound if the user isn't a member.
+func (s *Store) LeaveTask(ctx context.Context, userID, taskID int64) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM task_shares WHERE task_id = ? AND user_id = ?`, taskID, userID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListIncomingShares returns userID's pending incoming shares (their Requests),
+// newest first, with the task and owner named.
+func (s *Store) ListIncomingShares(ctx context.Context, userID int64) ([]ShareRequest, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT s.task_id, t.name, t.owner_id, u.username, s.created_at
+		 FROM task_shares s
+		 JOIN tasks t ON t.id = s.task_id
+		 JOIN users u ON u.id = t.owner_id
+		 WHERE s.user_id = ? AND s.status = 'pending'
+		 ORDER BY s.created_at DESC, s.task_id DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]ShareRequest, 0)
+	for rows.Next() {
+		var (
+			r       ShareRequest
+			created string
+		)
+		if err := rows.Scan(&r.TaskID, &r.TaskName, &r.OwnerID, &r.OwnerName, &created); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = parseTime(created)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ListTaskMembers returns everyone attached to a task: the owner first (status
+// "owner"), then shared members in invite order with their status. ErrNotFound
+// if the task does not exist.
+func (s *Store) ListTaskMembers(ctx context.Context, taskID int64) ([]TaskMember, error) {
+	owner := TaskMember{Status: "owner"}
+	switch err := s.db.QueryRowContext(ctx,
+		`SELECT u.id, u.username FROM tasks t JOIN users u ON u.id = t.owner_id WHERE t.id = ?`,
+		taskID).Scan(&owner.UserID, &owner.Username); {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, ErrNotFound
+	case err != nil:
+		return nil, err
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT u.id, u.username, s.status
+		 FROM task_shares s JOIN users u ON u.id = s.user_id
+		 WHERE s.task_id = ?
+		 ORDER BY s.created_at ASC, s.user_id ASC`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := []TaskMember{owner}
+	for rows.Next() {
+		var m TaskMember
+		if err := rows.Scan(&m.UserID, &m.Username, &m.Status); err != nil {
+			return nil, err
+		}
+		members = append(members, m)
+	}
+	return members, rows.Err()
+}

--- a/internal/store/shares_test.go
+++ b/internal/store/shares_test.go
@@ -1,0 +1,406 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// makeUser creates a user with the given name and returns its id.
+func makeUser(t *testing.T, st *Store, name string) int64 {
+	t.Helper()
+	u, err := st.CreateUser(context.Background(), UserInput{Username: name})
+	if err != nil {
+		t.Fatalf("CreateUser(%s): %v", name, err)
+	}
+	if !u.AllowShares {
+		t.Fatalf("new user %s should default to AllowShares=true", name)
+	}
+	return u.ID
+}
+
+// shareTask creates a task owned by owner and returns its id.
+func makeTask(t *testing.T, st *Store, owner int64, name string) int64 {
+	t.Helper()
+	task, err := st.CreateTask(context.Background(), owner, TaskInput{Name: name})
+	if err != nil {
+		t.Fatalf("CreateTask(%s): %v", name, err)
+	}
+	if task.OwnerID != owner {
+		t.Fatalf("task OwnerID = %d, want %d", task.OwnerID, owner)
+	}
+	return task.ID
+}
+
+// visible reports whether ListTasks for user includes taskID.
+func visible(t *testing.T, st *Store, user, taskID int64) bool {
+	t.Helper()
+	tasks, err := st.ListTasks(context.Background(), user)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	for _, tk := range tasks {
+		if tk.ID == taskID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestShareAcceptMakesTaskVisible(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	task := makeTask(t, st, alice, "Water the plants")
+
+	share, err := st.ShareTask(ctx, alice, task, bob)
+	if err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if share.Status != "pending" {
+		t.Fatalf("new share status = %q, want pending", share.Status)
+	}
+
+	// Pending: bob sees it only as a request, not among his tasks, and can't log it.
+	if visible(t, st, bob, task) {
+		t.Fatal("pending share should not be visible in bob's task list")
+	}
+	if _, err := st.GetTask(ctx, bob, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTask(bob) on pending share = %v, want ErrNotFound", err)
+	}
+	if _, err := st.AddCompletion(ctx, bob, task, time.Now(), ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("AddCompletion(bob) on pending share = %v, want ErrNotFound", err)
+	}
+	reqs, err := st.ListIncomingShares(ctx, bob)
+	if err != nil {
+		t.Fatalf("ListIncomingShares: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].TaskID != task || reqs[0].OwnerName != "alice" || reqs[0].TaskName != "Water the plants" {
+		t.Fatalf("unexpected incoming shares: %+v", reqs)
+	}
+
+	// Accept: now visible to bob, and gone from his requests.
+	if err := st.RespondToShare(ctx, bob, task, true); err != nil {
+		t.Fatalf("RespondToShare accept: %v", err)
+	}
+	if !visible(t, st, bob, task) {
+		t.Fatal("accepted share should be visible in bob's task list")
+	}
+	if _, err := st.GetTask(ctx, bob, task); err != nil {
+		t.Fatalf("GetTask(bob) after accept: %v", err)
+	}
+	if reqs, _ := st.ListIncomingShares(ctx, bob); len(reqs) != 0 {
+		t.Fatalf("accepted share should clear from requests, got %+v", reqs)
+	}
+	// Owner still sees it too.
+	if !visible(t, st, alice, task) {
+		t.Fatal("owner should still see a shared task")
+	}
+
+	members, err := st.ListTaskMembers(ctx, task)
+	if err != nil {
+		t.Fatalf("ListTaskMembers: %v", err)
+	}
+	if len(members) != 2 || members[0].Status != "owner" || members[0].UserID != alice ||
+		members[1].UserID != bob || members[1].Status != "accepted" {
+		t.Fatalf("unexpected members: %+v", members)
+	}
+}
+
+func TestShareRejectedCases(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	carol := makeUser(t, st, "carol")
+	task := makeTask(t, st, alice, "Back up the NAS")
+
+	// Sharing with yourself.
+	if _, err := st.ShareTask(ctx, alice, task, alice); !errors.Is(err, ErrShareSelf) {
+		t.Fatalf("share self = %v, want ErrShareSelf", err)
+	}
+	// Non-owner can't share.
+	if _, err := st.ShareTask(ctx, bob, task, carol); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("non-owner share = %v, want ErrNotFound", err)
+	}
+	// Unknown task / unknown recipient.
+	if _, err := st.ShareTask(ctx, alice, 9999, bob); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("share unknown task = %v, want ErrNotFound", err)
+	}
+	if _, err := st.ShareTask(ctx, alice, task, 9999); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("share to unknown user = %v, want ErrNotFound", err)
+	}
+	// Duplicate share.
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("first share: %v", err)
+	}
+	if _, err := st.ShareTask(ctx, alice, task, bob); !errors.Is(err, ErrAlreadyShared) {
+		t.Fatalf("duplicate share = %v, want ErrAlreadyShared", err)
+	}
+	// Opted-out recipient.
+	if err := st.SetUserAllowShares(ctx, carol, false); err != nil {
+		t.Fatalf("SetUserAllowShares: %v", err)
+	}
+	if got, err := st.GetUserAllowShares(ctx, carol); err != nil || got {
+		t.Fatalf("GetUserAllowShares(carol) = %v,%v; want false,nil", got, err)
+	}
+	if _, err := st.ShareTask(ctx, alice, task, carol); !errors.Is(err, ErrShareNotAllowed) {
+		t.Fatalf("share to opted-out user = %v, want ErrShareNotAllowed", err)
+	}
+}
+
+func TestDeclineShareLeavesTaskWithOwner(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	task := makeTask(t, st, alice, "Vacuum")
+
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, bob, task, false); err != nil {
+		t.Fatalf("RespondToShare decline: %v", err)
+	}
+	if visible(t, st, bob, task) {
+		t.Fatal("declined share should not be visible to bob")
+	}
+	if !visible(t, st, alice, task) {
+		t.Fatal("declined share: task should remain alice's")
+	}
+	// Declining again (no pending row) is ErrNotFound.
+	if err := st.RespondToShare(ctx, bob, task, true); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("respond with no pending share = %v, want ErrNotFound", err)
+	}
+}
+
+func TestMemberLogsRecordActorAndPermissions(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	task := makeTask(t, st, alice, "Clean the litter box")
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, bob, task, true); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+
+	// Each member logs; the actor is recorded.
+	aliceC, err := st.AddCompletion(ctx, alice, task, time.Now().Add(-2*time.Hour), "alice did it")
+	if err != nil {
+		t.Fatalf("AddCompletion(alice): %v", err)
+	}
+	if aliceC.UserID == nil || *aliceC.UserID != alice {
+		t.Fatalf("alice completion UserID = %v, want %d", aliceC.UserID, alice)
+	}
+	bobC, err := st.AddCompletion(ctx, bob, task, time.Now().Add(-1*time.Hour), "bob did it")
+	if err != nil {
+		t.Fatalf("AddCompletion(bob): %v", err)
+	}
+	if bobC.UserID == nil || *bobC.UserID != bob {
+		t.Fatalf("bob completion UserID = %v, want %d", bobC.UserID, bob)
+	}
+
+	// Both see the full shared history.
+	for _, u := range []int64{alice, bob} {
+		cs, err := st.ListCompletions(ctx, u, task)
+		if err != nil {
+			t.Fatalf("ListCompletions(%d): %v", u, err)
+		}
+		if len(cs) != 2 {
+			t.Fatalf("user %d sees %d completions, want 2", u, len(cs))
+		}
+	}
+
+	// A member may edit/delete their own entry, but not the owner's.
+	if _, err := st.UpdateCompletion(ctx, bob, bobC.ID, bobC.CompletedAt, "edited"); err != nil {
+		t.Fatalf("bob editing own completion: %v", err)
+	}
+	if _, err := st.UpdateCompletion(ctx, bob, aliceC.ID, aliceC.CompletedAt, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("bob editing alice's completion = %v, want ErrNotFound", err)
+	}
+	if err := st.DeleteCompletion(ctx, bob, aliceC.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("bob deleting alice's completion = %v, want ErrNotFound", err)
+	}
+	// The owner may edit/delete anyone's entry.
+	if _, err := st.UpdateCompletion(ctx, alice, bobC.ID, bobC.CompletedAt, "owner edit"); err != nil {
+		t.Fatalf("alice editing bob's completion: %v", err)
+	}
+	if err := st.DeleteCompletion(ctx, alice, bobC.ID); err != nil {
+		t.Fatalf("alice deleting bob's completion: %v", err)
+	}
+}
+
+func TestLeaveKeepsHistoryForOwner(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	task := makeTask(t, st, alice, "Shared chore")
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, bob, task, true); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	bobC, err := st.AddCompletion(ctx, bob, task, time.Now(), "bob logged")
+	if err != nil {
+		t.Fatalf("AddCompletion(bob): %v", err)
+	}
+
+	// Bob leaves: the task and bob's logged history persist for alice.
+	if err := st.LeaveTask(ctx, bob, task); err != nil {
+		t.Fatalf("LeaveTask: %v", err)
+	}
+	if visible(t, st, bob, task) {
+		t.Fatal("bob should not see the task after leaving")
+	}
+	if !visible(t, st, alice, task) {
+		t.Fatal("alice should still own the task after bob leaves")
+	}
+	cs, err := st.ListCompletions(ctx, alice, task)
+	if err != nil {
+		t.Fatalf("ListCompletions(alice): %v", err)
+	}
+	if len(cs) != 1 || cs[0].ID != bobC.ID {
+		t.Fatalf("alice should still see bob's completion, got %+v", cs)
+	}
+	// An ex-member can no longer edit the entry they left behind.
+	if _, err := st.UpdateCompletion(ctx, bob, bobC.ID, bobC.CompletedAt, "x"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ex-member editing left-behind completion = %v, want ErrNotFound", err)
+	}
+	// Leaving when not a member is ErrNotFound.
+	if err := st.LeaveTask(ctx, bob, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("leaving twice = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteByMemberIsLeave(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	task := makeTask(t, st, alice, "Chore")
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, bob, task, true); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+
+	// A member "deleting" the task only removes their own membership.
+	if err := st.DeleteTask(ctx, bob, task); err != nil {
+		t.Fatalf("DeleteTask(member): %v", err)
+	}
+	if visible(t, st, bob, task) {
+		t.Fatal("member delete should remove their access")
+	}
+	if !visible(t, st, alice, task) {
+		t.Fatal("member delete must not remove the task from the owner")
+	}
+}
+
+func TestDeleteByOwnerTransfersToEarliestMember(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	carol := makeUser(t, st, "carol")
+	task := makeTask(t, st, alice, "Group task")
+
+	for _, u := range []int64{bob, carol} {
+		if _, err := st.ShareTask(ctx, alice, task, u); err != nil {
+			t.Fatalf("ShareTask(%d): %v", u, err)
+		}
+		if err := st.RespondToShare(ctx, u, task, true); err != nil {
+			t.Fatalf("accept(%d): %v", u, err)
+		}
+	}
+	// Give the task history so we can prove it survives the transfer.
+	if _, err := st.AddCompletion(ctx, alice, task, time.Now(), "logged"); err != nil {
+		t.Fatalf("AddCompletion: %v", err)
+	}
+
+	// Owner deletes: ownership transfers to the earliest accepted member (bob).
+	if err := st.DeleteTask(ctx, alice, task); err != nil {
+		t.Fatalf("DeleteTask(owner with members): %v", err)
+	}
+	got, err := st.GetTask(ctx, bob, task)
+	if err != nil {
+		t.Fatalf("GetTask(bob) after transfer: %v", err)
+	}
+	if got.OwnerID != bob {
+		t.Fatalf("ownership transferred to %d, want bob (%d)", got.OwnerID, bob)
+	}
+	if got.CompletionCount != 1 {
+		t.Fatalf("history lost on transfer: completionCount = %d", got.CompletionCount)
+	}
+	// The original owner loses access; carol stays on as a member.
+	if _, err := st.GetTask(ctx, alice, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTask(alice) after transfer = %v, want ErrNotFound", err)
+	}
+	if !visible(t, st, carol, task) {
+		t.Fatal("carol should still see the task after the transfer")
+	}
+	members, err := st.ListTaskMembers(ctx, task)
+	if err != nil {
+		t.Fatalf("ListTaskMembers: %v", err)
+	}
+	if len(members) != 2 || members[0].UserID != bob || members[0].Status != "owner" ||
+		members[1].UserID != carol || members[1].Status != "accepted" {
+		t.Fatalf("unexpected members after transfer: %+v", members)
+	}
+}
+
+func TestDeleteByOwnerNoMembersRemovesTask(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	task := makeTask(t, st, alice, "Solo task")
+	if _, err := st.AddCompletion(ctx, alice, task, time.Now(), ""); err != nil {
+		t.Fatalf("AddCompletion: %v", err)
+	}
+
+	if err := st.DeleteTask(ctx, alice, task); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	if _, err := st.GetTask(ctx, alice, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTask after delete = %v, want ErrNotFound", err)
+	}
+	// Deleting again is ErrNotFound.
+	if err := st.DeleteTask(ctx, alice, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("delete missing task = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSharesAreIsolatedFromOtherUsers(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	alice := makeUser(t, st, "alice")
+	bob := makeUser(t, st, "bob")
+	stranger := makeUser(t, st, "stranger")
+	task := makeTask(t, st, alice, "Private-ish")
+	if _, err := st.ShareTask(ctx, alice, task, bob); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if err := st.RespondToShare(ctx, bob, task, true); err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	if visible(t, st, stranger, task) {
+		t.Fatal("an unrelated user must not see a shared task")
+	}
+	if _, err := st.GetTask(ctx, stranger, task); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTask(stranger) = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetUserAllowSharesUnknownUser(t *testing.T) {
+	st := newTestStore(t)
+	if _, err := st.GetUserAllowShares(context.Background(), 9999); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetUserAllowShares(unknown) = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestTaskTagsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner := testOwner(t, st)
+
+	task, err := st.CreateTask(ctx, owner, TaskInput{Name: "x", Tags: []string{"home", "plants"}})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if !reflect.DeepEqual(task.Tags, []string{"home", "plants"}) {
+		t.Fatalf("tags not persisted on create: %v", task.Tags)
+	}
+	got, err := st.GetTask(ctx, owner, task.ID)
+	if err != nil || !reflect.DeepEqual(got.Tags, []string{"home", "plants"}) {
+		t.Fatalf("tags not read back: %v (err %v)", got.Tags, err)
+	}
+
+	// Update replaces tags; clearing yields an empty (non-nil) slice.
+	upd, err := st.UpdateTask(ctx, owner, task.ID, TaskInput{Name: "x", Tags: nil})
+	if err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	if upd.Tags == nil || len(upd.Tags) != 0 {
+		t.Fatalf("expected empty tags after clear, got %#v", upd.Tags)
+	}
+
+	// A task created without tags reads back as an empty slice, not null.
+	plain, _ := st.CreateTask(ctx, owner, TaskInput{Name: "y"})
+	if plain.Tags == nil || len(plain.Tags) != 0 {
+		t.Fatalf("expected empty tags by default, got %#v", plain.Tags)
+	}
+}
+
+func TestTaskFolderRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner := testOwner(t, st)
+
+	task, err := st.CreateTask(ctx, owner, TaskInput{Name: "x", Folder: "Home"})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if task.Folder != "Home" {
+		t.Fatalf("folder not persisted on create: %q", task.Folder)
+	}
+	got, _ := st.GetTask(ctx, owner, task.ID)
+	if got.Folder != "Home" {
+		t.Fatalf("folder not read back: %q", got.Folder)
+	}
+	upd, _ := st.UpdateTask(ctx, owner, task.ID, TaskInput{Name: "x", Folder: ""})
+	if upd.Folder != "" {
+		t.Fatalf("expected folder cleared, got %q", upd.Folder)
+	}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -3,9 +3,23 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 )
+
+// encodeTags serialises a tag slice to the JSON text stored on the row, always
+// emitting a valid array ("[]" for none).
+func encodeTags(tags []string) string {
+	if len(tags) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
 
 // ErrNotFound is returned when a requested row does not exist.
 var ErrNotFound = errors.New("not found")
@@ -16,10 +30,20 @@ var ErrNotFound = errors.New("not found")
 const taskSelect = `
 	SELECT
 		t.id, t.name, t.description, t.interval_seconds,
-		t.color_fresh, t.color_overdue, t.freeze_color, t.archived_at, t.created_at, t.updated_at,
+		t.color_fresh, t.color_overdue, t.freeze_color, t.tags, t.folder, t.archived_at, t.created_at, t.updated_at, t.owner_id,
 		(SELECT MAX(completed_at) FROM completions c WHERE c.task_id = t.id) AS last_completed_at,
-		(SELECT COUNT(*)          FROM completions c WHERE c.task_id = t.id) AS completion_count
+		(SELECT COUNT(*)          FROM completions c WHERE c.task_id = t.id) AS completion_count,
+		EXISTS (SELECT 1 FROM task_shares sh WHERE sh.task_id = t.id) AS shared,
+		(SELECT u.username FROM completions c JOIN users u ON u.id = c.user_id
+		 WHERE c.task_id = t.id ORDER BY c.completed_at DESC, c.id DESC LIMIT 1) AS last_completed_by
 	FROM tasks t`
+
+// visibleTaskCond is a WHERE fragment matching tasks the given user may see: the
+// ones they own, plus those shared with them and accepted. Bind the user id
+// twice (once per "?"). Relies on the alias `t` for the tasks table.
+const visibleTaskCond = `(t.owner_id = ? OR EXISTS (
+		SELECT 1 FROM task_shares sh
+		WHERE sh.task_id = t.id AND sh.user_id = ? AND sh.status = 'accepted'))`
 
 // ListTasks returns all tasks. Ordering surfaces the most "actionable" first:
 // never-completed tasks, then those whose last completion is furthest in the
@@ -30,8 +54,8 @@ const taskSelect = `
 // UI, and is the part most likely to be tweaked.
 func (s *Store) ListTasks(ctx context.Context, ownerID int64) ([]Task, error) {
 	rows, err := s.db.QueryContext(ctx, taskSelect+`
-		WHERE t.owner_id = ?
-		ORDER BY last_completed_at IS NOT NULL, last_completed_at ASC, t.name COLLATE NOCASE ASC`, ownerID)
+		WHERE `+visibleTaskCond+`
+		ORDER BY last_completed_at IS NOT NULL, last_completed_at ASC, t.name COLLATE NOCASE ASC`, ownerID, ownerID)
 	if err != nil {
 		return nil, err
 	}
@@ -48,9 +72,10 @@ func (s *Store) ListTasks(ctx context.Context, ownerID int64) ([]Task, error) {
 	return tasks, rows.Err()
 }
 
-// GetTask returns a single task owned by ownerID, or ErrNotFound.
+// GetTask returns a single task visible to ownerID (owned or shared+accepted),
+// or ErrNotFound.
 func (s *Store) GetTask(ctx context.Context, ownerID, id int64) (Task, error) {
-	row := s.db.QueryRowContext(ctx, taskSelect+` WHERE t.id = ? AND t.owner_id = ?`, id, ownerID)
+	row := s.db.QueryRowContext(ctx, taskSelect+` WHERE t.id = ? AND `+visibleTaskCond, id, ownerID, ownerID)
 	t, err := scanTask(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Task{}, ErrNotFound
@@ -62,9 +87,9 @@ func (s *Store) GetTask(ctx context.Context, ownerID, id int64) (Task, error) {
 func (s *Store) CreateTask(ctx context.Context, ownerID int64, in TaskInput) (Task, error) {
 	now := time.Now().UTC().Format(timeLayout)
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO tasks (name, description, interval_seconds, color_fresh, color_overdue, freeze_color, owner_id, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		in.Name, in.Description, in.IntervalSeconds, in.ColorFresh, in.ColorOverdue, boolToInt(in.FreezeColor), ownerID, now, now,
+		`INSERT INTO tasks (name, description, interval_seconds, color_fresh, color_overdue, freeze_color, tags, folder, owner_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		in.Name, in.Description, in.IntervalSeconds, in.ColorFresh, in.ColorOverdue, boolToInt(in.FreezeColor), encodeTags(in.Tags), in.Folder, ownerID, now, now,
 	)
 	if err != nil {
 		return Task{}, err
@@ -84,9 +109,9 @@ func (s *Store) CreateTask(ctx context.Context, ownerID int64, in TaskInput) (Ta
 func (s *Store) UpdateTask(ctx context.Context, ownerID, id int64, in TaskInput) (Task, error) {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE tasks
-		 SET name = ?, description = ?, interval_seconds = ?, color_fresh = ?, color_overdue = ?, freeze_color = ?, updated_at = ?
+		 SET name = ?, description = ?, interval_seconds = ?, color_fresh = ?, color_overdue = ?, freeze_color = ?, tags = ?, folder = ?, updated_at = ?
 		 WHERE id = ? AND owner_id = ?`,
-		in.Name, in.Description, in.IntervalSeconds, in.ColorFresh, in.ColorOverdue, boolToInt(in.FreezeColor),
+		in.Name, in.Description, in.IntervalSeconds, in.ColorFresh, in.ColorOverdue, boolToInt(in.FreezeColor), encodeTags(in.Tags), in.Folder,
 		time.Now().UTC().Format(timeLayout), id, ownerID,
 	)
 	if err != nil {
@@ -118,16 +143,68 @@ func (s *Store) SetTaskArchived(ctx context.Context, ownerID, id int64, archived
 	return s.GetTask(ctx, ownerID, id)
 }
 
-// DeleteTask removes a task and (via ON DELETE CASCADE) its completions.
-func (s *Store) DeleteTask(ctx context.Context, ownerID, id int64) error {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM tasks WHERE id = ? AND owner_id = ?`, id, ownerID)
+// DeleteTask removes a user's access to a task, with shared-task-aware
+// semantics so that "delete" never destroys data another member still relies on:
+//
+//   - A non-owner (accepted or pending member) "deleting" the task simply leaves
+//     it — their share row is removed; the task and its history persist.
+//   - The owner deleting a task that still has accepted members transfers
+//     ownership to the earliest such member (dropping the original owner's
+//     access) rather than removing the task.
+//   - Only when the owner deletes a task with no accepted members is the row
+//     truly removed (cascading its completions and any pending invitations).
+//
+// userID is the acting user; ErrNotFound if they neither own nor are a member.
+func (s *Store) DeleteTask(ctx context.Context, userID, id int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	if n, _ := res.RowsAffected(); n == 0 {
+	defer tx.Rollback()
+
+	var ownerID int64
+	switch err := tx.QueryRowContext(ctx, `SELECT owner_id FROM tasks WHERE id = ?`, id).Scan(&ownerID); {
+	case errors.Is(err, sql.ErrNoRows):
 		return ErrNotFound
+	case err != nil:
+		return err
 	}
-	return nil
+
+	// A member leaving: drop only their share row.
+	if ownerID != userID {
+		res, err := tx.ExecContext(ctx, `DELETE FROM task_shares WHERE task_id = ? AND user_id = ?`, id, userID)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrNotFound // not the owner and not a member
+		}
+		return tx.Commit()
+	}
+
+	// Owner: transfer to the earliest accepted member if any, else delete.
+	var newOwner int64
+	switch err := tx.QueryRowContext(ctx,
+		`SELECT user_id FROM task_shares
+		 WHERE task_id = ? AND status = 'accepted'
+		 ORDER BY created_at ASC, user_id ASC LIMIT 1`, id).Scan(&newOwner); {
+	case errors.Is(err, sql.ErrNoRows):
+		if _, err := tx.ExecContext(ctx, `DELETE FROM tasks WHERE id = ?`, id); err != nil {
+			return err
+		}
+	case err != nil:
+		return err
+	default:
+		now := time.Now().UTC().Format(timeLayout)
+		if _, err := tx.ExecContext(ctx, `UPDATE tasks SET owner_id = ?, updated_at = ? WHERE id = ?`, newOwner, now, id); err != nil {
+			return err
+		}
+		// The promoted member is now the owner, not a member.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM task_shares WHERE task_id = ? AND user_id = ?`, id, newOwner); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func boolToInt(b bool) int {
@@ -150,19 +227,30 @@ func scanTask(sc scanner) (Task, error) {
 		colorFresh   sql.NullString
 		colorOverdue sql.NullString
 		freezeColor  int
+		tags         string
 		archivedAt   sql.NullString
 		created      string
 		updated      string
 		lastDone     sql.NullString
+		shared       int
+		lastBy       sql.NullString
 	)
 	if err := sc.Scan(
 		&t.ID, &t.Name, &t.Description, &interval,
-		&colorFresh, &colorOverdue, &freezeColor, &archivedAt, &created, &updated,
-		&lastDone, &t.CompletionCount,
+		&colorFresh, &colorOverdue, &freezeColor, &tags, &t.Folder, &archivedAt, &created, &updated, &t.OwnerID,
+		&lastDone, &t.CompletionCount, &shared, &lastBy,
 	); err != nil {
 		return Task{}, err
 	}
 	t.FreezeColor = freezeColor != 0
+	t.Tags = []string{}
+	if tags != "" {
+		_ = json.Unmarshal([]byte(tags), &t.Tags)
+	}
+	t.Shared = shared != 0
+	if lastBy.Valid {
+		t.LastCompletedBy = &lastBy.String
+	}
 	if interval.Valid {
 		t.IntervalSeconds = &interval.Int64
 	}

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -21,6 +21,9 @@ type User struct {
 	PasswordSet  bool      `json:"passwordSet"`
 	OIDCLinked   bool      `json:"oidcLinked"`
 	Approved     bool      `json:"approved"`
+	// AllowShares is the per-user opt-in (default true) to receiving shared
+	// tasks. When false, the share API refuses to target this user.
+	AllowShares bool `json:"allowShares"`
 	// Protected is set by the API layer (not the DB) for the bootstrap admin, so
 	// the UI can disable controls other admins aren't allowed to use.
 	Protected bool      `json:"protected"`
@@ -39,21 +42,23 @@ type UserInput struct {
 	Approved     *bool
 }
 
-const userSelect = `SELECT id, username, password_hash, role, oidc_subject, approved, created_at, updated_at FROM users`
+const userSelect = `SELECT id, username, password_hash, role, oidc_subject, approved, allow_shares, created_at, updated_at FROM users`
 
 func scanUser(sc scanner) (User, error) {
 	var (
-		u        User
-		hash     sql.NullString
-		subject  sql.NullString
-		approved int
-		created  string
-		updated  string
+		u           User
+		hash        sql.NullString
+		subject     sql.NullString
+		approved    int
+		allowShares int
+		created     string
+		updated     string
 	)
-	if err := sc.Scan(&u.ID, &u.Username, &hash, &u.Role, &subject, &approved, &created, &updated); err != nil {
+	if err := sc.Scan(&u.ID, &u.Username, &hash, &u.Role, &subject, &approved, &allowShares, &created, &updated); err != nil {
 		return User{}, err
 	}
 	u.Approved = approved != 0
+	u.AllowShares = allowShares != 0
 	if hash.Valid {
 		u.PasswordHash = &hash.String
 	}
@@ -199,6 +204,25 @@ func (s *Store) UnlinkOIDCSubject(ctx context.Context, id int64) error {
 	return s.touchUser(ctx, `UPDATE users SET oidc_subject = NULL, updated_at = ? WHERE id = ?`, time.Now().UTC().Format(timeLayout), id)
 }
 
+// SetUserAllowShares sets a user's opt-in for receiving shared tasks.
+func (s *Store) SetUserAllowShares(ctx context.Context, id int64, allow bool) error {
+	return s.touchUser(ctx, `UPDATE users SET allow_shares = ?, updated_at = ? WHERE id = ?`, boolToInt(allow), time.Now().UTC().Format(timeLayout), id)
+}
+
+// GetUserAllowShares reports whether a user accepts shared tasks. A missing user
+// returns ErrNotFound.
+func (s *Store) GetUserAllowShares(ctx context.Context, id int64) (bool, error) {
+	var v int
+	err := s.db.QueryRowContext(ctx, `SELECT allow_shares FROM users WHERE id = ?`, id).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, ErrNotFound
+	}
+	if err != nil {
+		return false, err
+	}
+	return v != 0, nil
+}
+
 func (s *Store) touchUser(ctx context.Context, query string, args ...any) error {
 	res, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
@@ -212,14 +236,24 @@ func (s *Store) touchUser(ctx context.Context, query string, args ...any) error 
 
 // DeleteUser removes a user (cascading their tasks, completions, and sessions).
 func (s *Store) DeleteUser(ctx context.Context, id int64) error {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, id)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	// A shared task the user owns transfers to a member instead of being
+	// cascaded away with the account; their solo tasks cascade as before.
+	if err := reassignSharedTasks(ctx, tx, id); err != nil {
+		return err
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, id)
 	if err != nil {
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		return ErrNotFound
 	}
-	return nil
+	return tx.Commit()
 }
 
 // --- destructive admin operations -------------------------------------------
@@ -234,11 +268,25 @@ func (s *Store) WipeAllTasks(ctx context.Context) error {
 // DeleteTasksByOwner deletes all of one user's tasks (and, by cascade, their
 // completions), keeping the account and its preferences. Returns the count.
 func (s *Store) DeleteTasksByOwner(ctx context.Context, ownerID int64) (int64, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM tasks WHERE owner_id = ?`, ownerID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	// Shared tasks with other members move to a member rather than being
+	// destroyed (the user effectively leaves); only solo tasks are deleted, so
+	// the returned count is the number actually removed.
+	if err := reassignSharedTasks(ctx, tx, ownerID); err != nil {
+		return 0, err
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM tasks WHERE owner_id = ?`, ownerID)
 	if err != nil {
 		return 0, err
 	}
 	n, _ := res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
 	return n, nil
 }
 
@@ -320,6 +368,24 @@ func (s *Store) MergeUsers(ctx context.Context, sourceID, targetID int64, moveDa
 	now := time.Now().UTC().Format(timeLayout)
 	if moveData {
 		if _, err := tx.ExecContext(ctx, `UPDATE tasks SET owner_id = ? WHERE owner_id = ?`, targetID, sourceID); err != nil {
+			return err
+		}
+		// Fold the source's completion authorship into the target so "logged by"
+		// survives the merge.
+		if _, err := tx.ExecContext(ctx, `UPDATE completions SET user_id = ? WHERE user_id = ?`, targetID, sourceID); err != nil {
+			return err
+		}
+		// If the target was already a member of a task it now owns, drop the now-
+		// redundant share row (an owner is never also a member).
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM task_shares WHERE user_id = ? AND task_id IN (SELECT id FROM tasks WHERE owner_id = ?)`,
+			targetID, targetID); err != nil {
+			return err
+		}
+	} else {
+		// Not moving data: the source's solo tasks cascade away with it, but a
+		// shared task transfers to a member so collaborators keep it.
+		if err := reassignSharedTasks(ctx, tx, sourceID); err != nil {
 			return err
 		}
 	}

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckSquare, ListTodo, Menu, Plus } from "lucide-react";
+import {
+  CheckSquare,
+  ChevronDown,
+  ChevronRight,
+  FolderTree,
+  ListTodo,
+  Menu,
+  Plus,
+  Search,
+  X,
+} from "lucide-react";
 
-import { api } from "@/lib/api";
-import { type Filter, FILTERS, matchesFilter } from "@/lib/filters";
+import { api, type Task } from "@/lib/api";
+import { type Filter, FILTERS, matchesFilter, SHARE_FILTERS } from "@/lib/filters";
+import { type SortKey, SORT_OPTIONS, sortTasks } from "@/lib/sort";
 import { taskStaleness } from "@/lib/staleness";
 import { usePrefs } from "@/lib/prefs";
 import { useFlip } from "@/lib/useFlip";
@@ -12,12 +23,14 @@ import { useNow } from "@/lib/useNow";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Sidebar } from "@/components/Sidebar";
+import { RequestsView } from "@/components/RequestsView";
 import { TaskCard } from "@/components/TaskCard";
 import { CreateTaskDialog } from "@/components/CreateTaskDialog";
 import { Calendar } from "@/components/Calendar";
 import { ActivityChart } from "@/components/ActivityChart";
 import { BulkBar } from "@/components/BulkBar";
 import { PreferencesSync } from "@/components/PreferencesSync";
+import { WhatsNew } from "@/components/WhatsNew";
 
 // Human-readable result of an OIDC account-link attempt (see the callback in
 // internal/api/oidc.go, which redirects back here with ?oidcLink=...).
@@ -29,9 +42,11 @@ const OIDC_LINK_MESSAGES: Record<string, string> = {
 
 export default function App() {
   const now = useNow(); // ticking clock so staleness/counts refresh over time
-  const { prefs } = usePrefs();
+  const { prefs, setPrefs } = usePrefs();
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<Filter>("all");
+  const [search, setSearch] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
 
   // After returning from an OIDC link attempt, surface the outcome and refresh
   // the cached user so the Settings UI reflects the new link state, then strip
@@ -74,6 +89,17 @@ export default function App() {
   });
   const tasks = data ?? [];
 
+  // Sharing: whether the feature is enabled (gates the Shared/Requests views),
+  // and the current count of incoming invites (drives the Requests pulse).
+  const { data: authConfig } = useQuery({ queryKey: ["auth-config"], queryFn: api.authConfig });
+  const shareEnabled = authConfig?.tasksShareable ?? false;
+  const { data: incoming } = useQuery({
+    queryKey: ["incoming-shares"],
+    queryFn: api.listIncomingShares,
+    enabled: shareEnabled,
+  });
+  const requestCount = incoming?.length ?? 0;
+
   // Animate task-grid layout changes: when a quick log / filter change / new
   // task reorders the grid, surviving cards glide to their new spot and
   // appearing ones fade in (see useFlip). Cards opt in via data-flip-key.
@@ -84,26 +110,96 @@ export default function App() {
   // Counts per sidebar view (recomputed as time passes via `now`). Archived
   // tasks are excluded from the active views and counted on their own.
   const counts = useMemo(() => {
-    const c: Record<Filter, number> = { all: 0, "due-soon": 0, overdue: 0, none: 0, archived: 0 };
+    const c: Record<Filter, number> = {
+      all: 0,
+      "due-soon": 0,
+      overdue: 0,
+      none: 0,
+      archived: 0,
+      shared: 0,
+      requests: requestCount,
+    };
     for (const t of tasks) {
       if (t.archivedAt != null) {
         c.archived += 1;
         continue;
       }
       c.all += 1;
+      if (t.shared) c.shared += 1;
       const s = taskStaleness(t, now);
       if (s === "due-soon" || s === "overdue" || s === "none") c[s] += 1;
     }
     return c;
-  }, [tasks, now]);
+  }, [tasks, now, requestCount]);
 
-  const visible = useMemo(
-    () => tasks.filter((t) => matchesFilter(t, filter, now)),
-    [tasks, filter, now],
-  );
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let list = tasks.filter((t) => matchesFilter(t, filter, now));
+    if (activeTag) {
+      list = list.filter((t) => t.tags.some((tag) => tag.toLowerCase() === activeTag.toLowerCase()));
+    }
+    if (q) {
+      list = list.filter(
+        (t) =>
+          t.name.toLowerCase().includes(q) ||
+          t.description.toLowerCase().includes(q) ||
+          t.tags.some((tag) => tag.toLowerCase().includes(q)),
+      );
+    }
+    return sortTasks(list, prefs.sortBy);
+  }, [tasks, filter, now, search, activeTag, prefs.sortBy]);
 
-  const filterLabel = FILTERS.find((f) => f.key === filter)?.label ?? "Tasks";
+  const filterLabel =
+    [...FILTERS, ...SHARE_FILTERS].find((f) => f.key === filter)?.label ?? "Tasks";
   const archivedView = filter === "archived";
+  const requestsView = filter === "requests";
+
+  // Folder grouping: collapsible sections (named folders A-Z, then "No folder").
+  const grouped = prefs.groupByFolder && !requestsView;
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(() => new Set());
+  const toggleFolder = (folder: string) =>
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(folder)) next.delete(folder);
+      else next.add(folder);
+      return next;
+    });
+  const groups = useMemo(() => {
+    const map = new Map<string, Task[]>();
+    for (const t of visible) {
+      const key = t.folder || "";
+      const arr = map.get(key);
+      if (arr) arr.push(t);
+      else map.set(key, [t]);
+    }
+    const named = [...map.keys()]
+      .filter((k) => k !== "")
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+    const order = map.has("") ? [...named, ""] : named;
+    return order.map((folder) => ({ folder, tasks: map.get(folder)! }));
+  }, [visible]);
+
+  const gridClassName = cn(
+    "grid gap-4",
+    (prefs.taskColumns === 0 || compact) && "grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3",
+  );
+  const gridStyle =
+    prefs.taskColumns > 0 && !compact
+      ? { gridTemplateColumns: `repeat(${prefs.taskColumns}, minmax(0, 1fr))` }
+      : undefined;
+  const renderCard = (task: Task) => (
+    <TaskCard
+      key={task.id}
+      task={task}
+      selectable={selectMode}
+      selected={selected.has(task.id)}
+      onToggleSelected={() => toggleSelected(task.id)}
+      onTagClick={(tag) => {
+        setActiveTag(tag);
+        setFilter("all");
+      }}
+    />
+  );
   // Only act on selected tasks that are actually in the current view.
   const selectedIds = useMemo(
     () => visible.filter((t) => selected.has(t.id)).map((t) => t.id),
@@ -114,6 +210,8 @@ export default function App() {
     <>
       {/* Load/save this account's theme + layout prefs server-side. */}
       <PreferencesSync />
+      {/* One-off "what's new" dialog after a version update. */}
+      <WhatsNew />
       <div className={cn("relative z-10 flex", sideBySide ? "h-[100dvh] overflow-hidden" : "min-h-[100dvh]")}>
         {/* Mobile/landscape drawer scrim */}
         {compact && sidebarOpen && (
@@ -142,6 +240,7 @@ export default function App() {
               setSelected(new Set());
             }}
             counts={counts}
+            shareEnabled={shareEnabled}
             onClose={() => setSidebarOpen(false)}
           />
         </aside>
@@ -166,7 +265,9 @@ export default function App() {
             >
               <h2 className="truncate text-sm font-semibold">{filterLabel}</h2>
               <p className="text-xs text-muted-foreground">
-                {visible.length} {visible.length === 1 ? "task" : "tasks"}
+                {requestsView
+                  ? `${requestCount} ${requestCount === 1 ? "request" : "requests"}`
+                  : `${visible.length} ${visible.length === 1 ? "task" : "tasks"}`}
               </p>
             </div>
 
@@ -196,43 +297,109 @@ export default function App() {
             )}
           >
             <div className={cn("min-w-0 flex-1", sideBySide && "overflow-y-auto p-4")}>
-              {isLoading && <GridSkeleton stagger={views} />}
+              {!requestsView && tasks.length > 0 && (
+                <div className="mb-4 flex flex-wrap items-center gap-2">
+                  <div className="relative min-w-[8rem] flex-1">
+                    <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <input
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      placeholder="Search tasks"
+                      aria-label="Search tasks"
+                      className="h-9 w-full rounded-md border border-input bg-transparent pl-8 pr-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    />
+                  </div>
+                  {activeTag && (
+                    <button
+                      type="button"
+                      onClick={() => setActiveTag(null)}
+                      className="inline-flex items-center gap-1 rounded-md bg-primary/15 px-2 py-1.5 text-xs font-medium text-primary"
+                    >
+                      {activeTag}
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                  <select
+                    value={prefs.sortBy}
+                    onChange={(e) => setPrefs({ sortBy: e.target.value as SortKey })}
+                    aria-label="Sort tasks"
+                    className="h-9 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {SORT_OPTIONS.map((o) => (
+                      <option key={o.key} value={o.key}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    variant={prefs.groupByFolder ? "secondary" : "outline"}
+                    size="sm"
+                    className="h-9"
+                    aria-pressed={prefs.groupByFolder}
+                    title="Group by folder"
+                    onClick={() => setPrefs({ groupByFolder: !prefs.groupByFolder })}
+                  >
+                    <FolderTree /> Group
+                  </Button>
+                </div>
+              )}
 
-              {isError && (
+              {requestsView && <RequestsView animate={views} />}
+
+              {!requestsView && isLoading && <GridSkeleton stagger={views} />}
+
+              {!requestsView && isError && (
                 <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
                   Failed to load tasks: {(error as Error).message}
                 </div>
               )}
 
-              {!isLoading && !isError && visible.length === 0 && (
-                <EmptyState filter={filter} animate={views} />
+              {!requestsView && !isLoading && !isError && visible.length === 0 &&
+                (search.trim() || activeTag ? (
+                  <p className="rounded-lg border border-dashed py-12 text-center text-sm text-muted-foreground">
+                    No tasks match.
+                  </p>
+                ) : (
+                  <EmptyState filter={filter} animate={views} />
+                ))}
+
+              {/* Flat grid (default). A fixed column count is for roomy screens
+                  only — phones / landscape phones fall back to the responsive
+                  1→2→3 grid so cards don't get crushed into slivers. */}
+              {!requestsView && !grouped && visible.length > 0 && (
+                <div ref={gridRef} className={gridClassName} style={gridStyle}>
+                  {visible.map(renderCard)}
+                </div>
               )}
 
-              {visible.length > 0 && (
-                <div
-                  ref={gridRef}
-                  className={cn(
-                    "grid gap-4",
-                    // A fixed column count is for roomy screens only — on phones /
-                    // landscape phones fall back to the responsive 1→2→3 grid so
-                    // cards don't get crushed into unreadable slivers.
-                    (prefs.taskColumns === 0 || compact) && "grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3",
-                  )}
-                  style={
-                    prefs.taskColumns > 0 && !compact
-                      ? { gridTemplateColumns: `repeat(${prefs.taskColumns}, minmax(0, 1fr))` }
-                      : undefined
-                  }
-                >
-                  {visible.map((task) => (
-                    <TaskCard
-                      key={task.id}
-                      task={task}
-                      selectable={selectMode}
-                      selected={selected.has(task.id)}
-                      onToggleSelected={() => toggleSelected(task.id)}
-                    />
-                  ))}
+              {/* Grouped into collapsible folder sections. */}
+              {!requestsView && grouped && visible.length > 0 && (
+                <div className="space-y-5">
+                  {groups.map(({ folder, tasks: folderTasks }) => {
+                    const isCollapsed = collapsedFolders.has(folder);
+                    return (
+                      <section key={folder || "__none"}>
+                        <button
+                          type="button"
+                          onClick={() => toggleFolder(folder)}
+                          className="mb-2 flex w-full items-center gap-1.5 text-sm font-semibold"
+                        >
+                          {isCollapsed ? (
+                            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                          ) : (
+                            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                          )}
+                          <span>{folder || "No folder"}</span>
+                          <span className="text-xs font-normal text-muted-foreground">{folderTasks.length}</span>
+                        </button>
+                        {!isCollapsed && (
+                          <div className={gridClassName} style={gridStyle}>
+                            {folderTasks.map(renderCard)}
+                          </div>
+                        )}
+                      </section>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -32,6 +32,8 @@ export function AdminPanel() {
       )}
       <OIDCSettings />
       <hr className="border-border/60" />
+      <SharingSettings />
+      <hr className="border-border/60" />
       <BrandingSettings />
       <hr className="border-border/60" />
       <PendingUsers />
@@ -754,6 +756,35 @@ function RegistrationSettings() {
           className="h-4 w-4 accent-primary"
           checked={data?.reg_approval ?? false}
           onChange={(e) => save.mutate({ reg_approval: e.target.checked })}
+        />
+      </label>
+    </section>
+  );
+}
+
+/** Admin gate for the whole shared-tasks feature. */
+function SharingSettings() {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({ queryKey: ["settings"], queryFn: api.getSettings });
+  const save = useMutation({
+    mutationFn: (patch: SettingsPatch) => api.putSettings(patch),
+    onSuccess: (next) => queryClient.setQueryData(["settings"], next),
+  });
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold">Task sharing</h3>
+      <label className="flex items-center justify-between gap-2 text-sm">
+        <span className="text-muted-foreground">
+          Let users share tasks
+          <span className="block text-xs">
+            Adds a Share action and the Shared / Requests views. Users can opt out individually.
+          </span>
+        </span>
+        <input
+          type="checkbox"
+          className="h-4 w-4 accent-primary"
+          checked={data?.tasks_shareable ?? false}
+          onChange={(e) => save.mutate({ tasks_shareable: e.target.checked })}
         />
       </label>
     </section>

--- a/web/src/components/AuthPage.tsx
+++ b/web/src/components/AuthPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, KeyRound, LogIn } from "lucide-react";
+import { Check, KeyRound, LogIn } from "lucide-react";
 
 import {
   api,
@@ -108,7 +108,7 @@ export function AuthPage() {
                 <img src={branding.icon} alt="" className="h-11 w-11 rounded-xl object-cover shadow" />
               ) : (
                 <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow">
-                  <CheckCircle2 className="h-6 w-6" />
+                  <Check className="h-6 w-6" strokeWidth={3} />
                 </div>
               ))}
             {!branding.loginHideText && (

--- a/web/src/components/ChangelogDialog.tsx
+++ b/web/src/components/ChangelogDialog.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Bug, RefreshCw, Sparkles } from "lucide-react";
+
+import { api } from "@/lib/api";
+import { DEMO } from "@/lib/demo";
+import { useAuth } from "@/components/AuthProvider";
+import { compareVersions, CURRENT_VERSION, formatReleaseDate, type Release, RELEASES } from "@/lib/releases";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+/** ReleaseEntry renders one version: a tag, its date, and the change list with
+ *  a sparkles (feature) or bug (fix) icon per line, plus an optional grey note.
+ *  Shared by the changelog and what's-new dialogs. */
+export function ReleaseEntry({ release }: { release: Release }) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2">
+        <span className="rounded bg-secondary px-1.5 py-0.5 text-xs font-medium text-secondary-foreground">
+          v{release.version}
+        </span>
+        <span className="text-xs text-muted-foreground">{formatReleaseDate(release.date)}</span>
+      </div>
+      <ul className="space-y-1.5">
+        {release.changes.map((c, i) => (
+          <li key={i} className="flex items-start gap-2 text-sm">
+            {c.kind === "feature" ? (
+              <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+            ) : (
+              <Bug className="mt-0.5 h-3.5 w-3.5 shrink-0 text-rose-400" />
+            )}
+            <span>
+              {c.text}
+              {c.note && <span className="text-muted-foreground"> - {c.note}</span>}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** The full changelog: every release, newest first. Opened from the version label. */
+export function ChangelogDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { user } = useAuth();
+  // The update check is an admin concern; regular users don't manage upgrades.
+  const showUpdateCheck = !DEMO && user?.role === "admin";
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Changelog</DialogTitle>
+        </DialogHeader>
+        <div className="-mr-2 max-h-[55vh] space-y-5 overflow-y-auto pr-2">
+          {RELEASES.map((r) => (
+            <ReleaseEntry key={r.version} release={r} />
+          ))}
+        </div>
+        {showUpdateCheck && <UpdateCheck />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// UpdateCheck reports whether a newer version has been released. It only checks
+// and informs — there is no in-app update action.
+function UpdateCheck() {
+  const [state, setState] = useState<"idle" | "checking">("idle");
+  const [result, setResult] = useState<string | null>(null);
+
+  const check = async () => {
+    setState("checking");
+    setResult(null);
+    try {
+      const { latest } = await api.checkLatestVersion();
+      if (!latest) {
+        setResult("Couldn't check for updates right now.");
+      } else if (compareVersions(latest, CURRENT_VERSION) > 0) {
+        setResult(`Update available: v${latest} (you have v${CURRENT_VERSION}).`);
+      } else {
+        setResult(`You're on the latest version (v${CURRENT_VERSION}).`);
+      }
+    } catch {
+      setResult("Couldn't check for updates right now.");
+    } finally {
+      setState("idle");
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-t pt-3 text-xs">
+      <Button variant="outline" size="sm" disabled={state === "checking"} onClick={check}>
+        <RefreshCw className={state === "checking" ? "animate-spin" : undefined} />
+        {state === "checking" ? "Checking…" : "Check for updates"}
+      </Button>
+      {result && <span className="text-muted-foreground">{result}</span>}
+    </div>
+  );
+}

--- a/web/src/components/CreateTaskDialog.tsx
+++ b/web/src/components/CreateTaskDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 
-import { api } from "@/lib/api";
+import { api, type Task } from "@/lib/api";
 import { useToast } from "@/components/ui/Toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +18,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { IntervalField } from "@/components/IntervalField";
+import { TagInput } from "@/components/ui/TagInput";
+import { FolderInput } from "@/components/ui/FolderInput";
+import { folderNames } from "@/lib/folders";
 
 /**
  * CreateTaskDialog owns the "new task" form. `trigger` lets callers supply their
@@ -29,7 +32,10 @@ export function CreateTaskDialog({ trigger }: { trigger?: React.ReactNode }) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [intervalSeconds, setIntervalSeconds] = useState<number | null>(null);
+  const [tags, setTags] = useState<string[]>([]);
+  const [folder, setFolder] = useState("");
   const queryClient = useQueryClient();
+  const folderSuggestions = folderNames(queryClient.getQueryData<Task[]>(["tasks"]) ?? []);
 
   const toast = useToast();
   const mutation = useMutation({
@@ -38,12 +44,16 @@ export function CreateTaskDialog({ trigger }: { trigger?: React.ReactNode }) {
         name: name.trim(),
         description: description.trim() || undefined,
         intervalSeconds,
+        tags,
+        folder: folder.trim(),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
       setName("");
       setDescription("");
       setIntervalSeconds(null);
+      setTags([]);
+      setFolder("");
       setOpen(false);
       toast("Task created", { tone: "success" });
     },
@@ -93,6 +103,14 @@ export function CreateTaskDialog({ trigger }: { trigger?: React.ReactNode }) {
             />
           </div>
           <IntervalField value={intervalSeconds} onChange={setIntervalSeconds} />
+          <div className="space-y-2">
+            <Label>Tags (optional)</Label>
+            <TagInput value={tags} onChange={setTags} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="task-folder">Folder (optional)</Label>
+            <FolderInput value={folder} onChange={setFolder} suggestions={folderSuggestions} />
+          </div>
           {mutation.isError && (
             <p className="text-sm text-destructive">{(mutation.error as Error).message}</p>
           )}

--- a/web/src/components/ManageTaskDialog.tsx
+++ b/web/src/components/ManageTaskDialog.tsx
@@ -1,10 +1,11 @@
-import { useId, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Archive, ArchiveRestore, Pencil, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, LogOut, Pencil, Trash2, UserPlus, Users } from "lucide-react";
 
 import { api, type Completion, type Task } from "@/lib/api";
 import { formatDateTime } from "@/lib/time";
 import { usePrefs } from "@/lib/prefs";
+import { useAuth } from "@/components/AuthProvider";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/Toast";
 import { ColorField } from "@/components/ui/ColorPicker";
@@ -13,6 +14,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { IntervalField } from "@/components/IntervalField";
+import { TagInput } from "@/components/ui/TagInput";
+import { FolderInput } from "@/components/ui/FolderInput";
+import { folderNames } from "@/lib/folders";
 
 /**
  * ManageTaskPanel is the "manage" surface for a task, rendered as the body of
@@ -24,17 +28,129 @@ import { IntervalField } from "@/components/IntervalField";
  * `onClose` closes the owning window (after a successful save or delete).
  */
 export function ManageTaskPanel({ task, onClose }: { task: Task; onClose: () => void }) {
+  const { user } = useAuth();
+  // A member (not the owner) can log and review history and leave, but not edit
+  // or archive the definition — those stay with the owner.
+  const isOwner = user ? task.ownerId === user.id : true;
+
   return (
     <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">Edit the task, review its history, or delete it.</p>
+      {isOwner ? (
+        <>
+          <p className="text-sm text-muted-foreground">Edit the task, review its history, or delete it.</p>
+          <EditSection task={task} onDone={onClose} />
+        </>
+      ) : (
+        <div>
+          <h3 className="text-base font-semibold">{task.name}</h3>
+          {task.description && <p className="mt-0.5 text-sm text-muted-foreground">{task.description}</p>}
+          <p className="mt-1 text-xs text-muted-foreground">
+            Shared with you — log it and review the history, or leave it below.
+          </p>
+        </div>
+      )}
 
-      <EditSection task={task} onDone={onClose} />
+      <ShareSection task={task} isOwner={isOwner} onLeft={onClose} />
 
       <hr className="border-border/60" />
       <HistorySection task={task} />
 
+      {isOwner && (
+        <>
+          <hr className="border-border/60" />
+          <DangerZone task={task} onDeleted={onClose} />
+        </>
+      )}
+    </div>
+  );
+}
+
+// ShareSection is the collaboration surface, shown only when the admin has
+// enabled sharing. The owner invites people (by username) and sees the member
+// list; a member sees who's on it and can leave.
+function ShareSection({ task, isOwner, onLeft }: { task: Task; isOwner: boolean; onLeft: () => void }) {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [username, setUsername] = useState("");
+  const { data: config } = useQuery({ queryKey: ["auth-config"], queryFn: api.authConfig });
+  const { data: members } = useQuery({
+    queryKey: ["members", task.id],
+    queryFn: () => api.listMembers(task.id),
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["members", task.id] });
+    queryClient.invalidateQueries({ queryKey: ["tasks"] });
+  };
+
+  const share = useMutation({
+    mutationFn: () => api.shareTask(task.id, username.trim()),
+    onSuccess: () => {
+      setUsername("");
+      invalidate();
+      toast("Invitation sent", { tone: "success" });
+    },
+    onError: (e) => toast((e as Error).message, { tone: "error" }),
+  });
+
+  const leave = useMutation({
+    mutationFn: () => api.leaveTask(task.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+      toast("You left the task", { tone: "success" });
+      onLeft();
+    },
+    onError: (e) => toast((e as Error).message, { tone: "error" }),
+  });
+
+  if (!config?.tasksShareable) return null;
+
+  return (
+    <div className="space-y-2">
       <hr className="border-border/60" />
-      <DangerZone task={task} onDeleted={onClose} />
+      <p className="flex items-center gap-1.5 text-sm font-medium">
+        <Users className="h-4 w-4" /> Sharing
+      </p>
+
+      {members && members.length > 0 && (
+        <ul className="space-y-1">
+          {members.map((m) => (
+            <li key={m.userId} className="flex items-center justify-between gap-2 text-sm">
+              <span className="truncate">{m.username}</span>
+              <span className="shrink-0 text-xs capitalize text-muted-foreground">
+                {m.status === "pending" ? "invited" : m.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isOwner ? (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (username.trim()) share.mutate();
+          }}
+          className="flex gap-2 pt-1"
+        >
+          <Input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Share with username"
+            aria-label="Username to share with"
+          />
+          <Button type="submit" size="sm" disabled={!username.trim() || share.isPending}>
+            <UserPlus /> Share
+          </Button>
+        </form>
+      ) : (
+        <div className="pt-1">
+          <Button variant="outline" size="sm" disabled={leave.isPending} onClick={() => leave.mutate()}>
+            <LogOut /> Leave task
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
@@ -49,7 +165,10 @@ function EditSection({ task, onDone }: { task: Task; onDone: () => void }) {
   const [colorFresh, setColorFresh] = useState<string | null>(task.colorFresh);
   const [colorOverdue, setColorOverdue] = useState<string | null>(task.colorOverdue);
   const [freezeColor, setFreezeColor] = useState(task.freezeColor);
+  const [tags, setTags] = useState<string[]>(task.tags);
+  const [folder, setFolder] = useState(task.folder);
   const queryClient = useQueryClient();
+  const folderSuggestions = folderNames(queryClient.getQueryData<Task[]>(["tasks"]) ?? []);
 
   const toast = useToast();
   const mutation = useMutation({
@@ -61,6 +180,8 @@ function EditSection({ task, onDone }: { task: Task; onDone: () => void }) {
         colorFresh,
         colorOverdue,
         freezeColor,
+        tags,
+        folder: folder.trim(),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
@@ -91,6 +212,16 @@ function EditSection({ task, onDone }: { task: Task; onDone: () => void }) {
         />
       </div>
       <IntervalField value={intervalSeconds} onChange={setIntervalSeconds} />
+
+      <div className="space-y-2">
+        <Label>Tags</Label>
+        <TagInput value={tags} onChange={setTags} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Folder</Label>
+        <FolderInput value={folder} onChange={setFolder} suggestions={folderSuggestions} />
+      </div>
 
       <div className="space-y-2">
         <Label>Colours</Label>
@@ -152,6 +283,17 @@ function HistorySection({ task }: { task: Task }) {
     queryKey: ["completions", task.id],
     queryFn: () => api.listCompletions(task.id),
   });
+  // On a shared task, resolve each completion's author id to a name ("by X").
+  const { data: members } = useQuery({
+    queryKey: ["members", task.id],
+    queryFn: () => api.listMembers(task.id),
+    enabled: task.shared,
+  });
+  const names = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const mem of members ?? []) m.set(mem.userId, mem.username);
+    return m;
+  }, [members]);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["completions", task.id] });
@@ -168,7 +310,12 @@ function HistorySection({ task }: { task: Task }) {
           <p className="text-sm text-muted-foreground">No completions logged yet.</p>
         )}
         {completions?.map((c) => (
-          <HistoryRow key={c.id} completion={c} onChanged={invalidate} />
+          <HistoryRow
+            key={c.id}
+            completion={c}
+            author={task.shared && c.userId != null ? names.get(c.userId) : undefined}
+            onChanged={invalidate}
+          />
         ))}
       </div>
     </div>
@@ -176,8 +323,17 @@ function HistorySection({ task }: { task: Task }) {
 }
 
 // HistoryRow shows one completion and lets you edit its time/note in place
-// (PATCH /api/completions/{id}) or delete it.
-function HistoryRow({ completion: c, onChanged }: { completion: Completion; onChanged: () => void }) {
+// (PATCH /api/completions/{id}) or delete it. `author` (when set) names who
+// logged it, shown on shared tasks.
+function HistoryRow({
+  completion: c,
+  author,
+  onChanged,
+}: {
+  completion: Completion;
+  author?: string;
+  onChanged: () => void;
+}) {
   const [editing, setEditing] = useState(false);
   const [when, setWhen] = useState(() => new Date(c.completedAt));
   const [note, setNote] = useState(c.note);
@@ -226,7 +382,10 @@ function HistoryRow({ completion: c, onChanged }: { completion: Completion; onCh
   return (
     <div className="flex items-start justify-between gap-3 rounded-lg border bg-muted/30 p-2.5">
       <div className="min-w-0">
-        <p className="text-sm font-medium">{formatDateTime(c.completedAt)}</p>
+        <p className="text-sm font-medium">
+          {formatDateTime(c.completedAt)}
+          {author && <span className="font-normal text-muted-foreground"> · by {author}</span>}
+        </p>
         {c.note && <p className="mt-0.5 break-words text-sm text-muted-foreground">{c.note}</p>}
       </div>
       <div className="flex shrink-0 items-center gap-1">

--- a/web/src/components/RequestsView.tsx
+++ b/web/src/components/RequestsView.tsx
@@ -1,0 +1,88 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Inbox, X } from "lucide-react";
+
+import { api } from "@/lib/api";
+import { formatDateTime } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+/**
+ * RequestsView is the body of the "Requests" sidebar view: the current user's
+ * pending incoming share invitations, each acceptable or declinable. Accepting
+ * adds the task to their list; declining drops the invite.
+ */
+export function RequestsView({ animate = true }: { animate?: boolean }) {
+  const queryClient = useQueryClient();
+  const { data: requests, isLoading } = useQuery({
+    queryKey: ["incoming-shares"],
+    queryFn: api.listIncomingShares,
+  });
+
+  const respond = useMutation({
+    mutationFn: ({ taskId, accept }: { taskId: number; accept: boolean }) =>
+      api.respondShare(taskId, accept),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["incoming-shares"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  if (!requests || requests.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col items-center justify-center rounded-xl border border-dashed py-20 text-center",
+          animate && "animate-in fade-in-0 zoom-in-95 duration-300",
+        )}
+      >
+        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <Inbox className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <h2 className="text-base font-semibold">No requests</h2>
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          When someone shares a task with you, it'll appear here to accept or decline.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-3", animate && "animate-in fade-in-0 duration-300")}>
+      {requests.map((req) => (
+        <div
+          key={req.taskId}
+          className="flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-card p-4"
+        >
+          <div className="min-w-0">
+            <p className="truncate font-medium">{req.taskName}</p>
+            <p className="text-xs text-muted-foreground">
+              Shared by {req.ownerName} · {formatDateTime(req.createdAt)}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={respond.isPending}
+              onClick={() => respond.mutate({ taskId: req.taskId, accept: false })}
+            >
+              <X /> Decline
+            </Button>
+            <Button
+              size="sm"
+              disabled={respond.isPending}
+              onClick={() => respond.mutate({ taskId: req.taskId, accept: true })}
+            >
+              <Check /> Accept
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, LogOut, Settings, X } from "lucide-react";
+import { Check, LogOut, Settings, X } from "lucide-react";
 
 import { api } from "@/lib/api";
-import { type Filter, FILTERS } from "@/lib/filters";
+import { type Filter, FILTERS, SHARE_FILTERS } from "@/lib/filters";
 import { clearStoredPreferences, usePrefs } from "@/lib/prefs";
 import { DEFAULT_THEME } from "@/lib/theme";
 import { cn } from "@/lib/utils";
@@ -12,6 +12,8 @@ import { Button } from "@/components/ui/button";
 import { SlidingHighlight } from "@/components/ui/SlidingHighlight";
 import { CreateTaskDialog } from "@/components/CreateTaskDialog";
 import { SettingsPanel } from "@/components/SettingsPanel";
+import { ChangelogDialog } from "@/components/ChangelogDialog";
+import { currentRelease, formatReleaseDate } from "@/lib/releases";
 import { useAuth } from "@/components/AuthProvider";
 import { useTheme } from "@/components/ThemeProvider";
 import { useWindows } from "@/components/windows/WindowManager";
@@ -29,11 +31,14 @@ export function Sidebar({
   filter,
   onFilterChange,
   counts,
+  shareEnabled = false,
   onClose,
 }: {
   filter: Filter;
   onFilterChange: (f: Filter) => void;
   counts: Record<Filter, number>;
+  /** Whether task sharing is on (shows the Shared + Requests views). */
+  shareEnabled?: boolean;
   onClose?: () => void;
 }) {
   const windows = useWindows();
@@ -43,6 +48,8 @@ export function Sidebar({
   const { prefs } = usePrefs();
   const branding = useBranding();
   const navRef = useRef<HTMLElement>(null);
+  const [changelogOpen, setChangelogOpen] = useState(false);
+  const release = currentRelease();
   // Signing out: close every open window and wipe the query cache so the next
   // account never sees the previous user's tasks/calendar (their data is
   // owner-scoped server-side, so stale cache is the only leak — and editing it
@@ -69,7 +76,7 @@ export function Sidebar({
             <img src={branding.icon} alt="" className="h-9 w-9 shrink-0 rounded-lg object-cover shadow" />
           ) : (
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow">
-              <CheckCircle2 className="h-5 w-5" />
+              <Check className="h-5 w-5" strokeWidth={3} />
             </div>
           )}
           <div className="min-w-0">
@@ -93,8 +100,10 @@ export function Sidebar({
           pick up a sibling margin; the bubble glides to the selected view. */}
       <nav ref={navRef} className="relative mt-6 flex flex-col gap-1">
         <SlidingHighlight containerRef={navRef} activeKey={filter} className="rounded-md bg-primary/15" />
-        {FILTERS.map((f) => {
+        {(shareEnabled ? [...FILTERS, ...SHARE_FILTERS] : FILTERS).map((f) => {
           const active = filter === f.key;
+          // A pending invite gives the Requests view a calm accent pulse.
+          const pulse = f.key === "requests" && counts.requests > 0;
           return (
             <button
               key={f.key}
@@ -115,11 +124,23 @@ export function Sidebar({
                   active ? "scale-y-100 opacity-100" : "scale-y-0 opacity-0",
                 )}
               />
-              <span>{f.label}</span>
+              <span className="flex items-center gap-1.5">
+                {f.label}
+                {pulse && (
+                  <span
+                    aria-hidden
+                    className={cn("h-1.5 w-1.5 rounded-full bg-primary", prefs.animFeedback && "animate-pulse")}
+                  />
+                )}
+              </span>
               {/* Keyed by the value so a changing count pops in. */}
               <span
                 key={counts[f.key]}
-                className={cn("text-xs tabular-nums", prefs.animFeedback && "animate-in zoom-in-75 duration-200")}
+                className={cn(
+                  "text-xs tabular-nums",
+                  pulse && "font-medium text-primary",
+                  prefs.animFeedback && "animate-in zoom-in-75 duration-200",
+                )}
               >
                 {counts[f.key]}
               </span>
@@ -148,7 +169,19 @@ export function Sidebar({
         </div>
 
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[11px] text-muted-foreground">v{__APP_VERSION__}</span>
+          <button
+            type="button"
+            onClick={() => setChangelogOpen(true)}
+            title={release ? `Released ${formatReleaseDate(release.date)}` : undefined}
+            className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            v{__APP_VERSION__}
+            {release && release.changes.length > 0 && (
+              <span className="rounded bg-secondary px-1 text-[10px] tabular-nums text-secondary-foreground">
+                {release.changes.length}
+              </span>
+            )}
+          </button>
           <Button
             variant="outline"
             size="sm"
@@ -164,6 +197,7 @@ export function Sidebar({
             <Settings /> Settings
           </Button>
         </div>
+        <ChangelogDialog open={changelogOpen} onOpenChange={setChangelogOpen} />
       </div>
     </div>
   );

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Check, Clock, Settings2, Zap } from "lucide-react";
+import { Check, Clock, Settings2, Users, Zap } from "lucide-react";
 
 import { api, type Task } from "@/lib/api";
 import { formatDateTime, formatDue, formatInterval, timeSince } from "@/lib/time";
@@ -25,11 +25,13 @@ export function TaskCard({
   selectable = false,
   selected = false,
   onToggleSelected,
+  onTagClick,
 }: {
   task: Task;
   selectable?: boolean;
   selected?: boolean;
   onToggleSelected?: () => void;
+  onTagClick?: (tag: string) => void;
 }) {
   // Subscribe to the ticking clock so relative times / colours stay current.
   const now = useNow();
@@ -106,6 +108,9 @@ export function TaskCard({
               </span>
             )}
             <CardTitle className="truncate text-base">{task.name}</CardTitle>
+            {task.shared && (
+              <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="Shared task" />
+            )}
           </div>
           {/* Keyed by the count so each new log pops the badge in. */}
           <Badge
@@ -137,6 +142,9 @@ export function TaskCard({
         {!compact && task.lastCompletedAt && (
           <p className="pl-[18px] text-xs text-muted-foreground">
             {formatDateTime(task.lastCompletedAt)}
+            {task.shared && task.lastCompletedBy && (
+              <span> · by {task.lastCompletedBy}</span>
+            )}
           </p>
         )}
 
@@ -168,6 +176,24 @@ export function TaskCard({
                 )}
               </p>
             )}
+          </div>
+        )}
+
+        {task.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 pt-1">
+            {task.tags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTagClick?.(tag);
+                }}
+                className="rounded bg-secondary px-1.5 py-0.5 text-[10px] text-secondary-foreground transition-colors hover:bg-secondary/70"
+              >
+                {tag}
+              </button>
+            ))}
           </div>
         )}
       </CardContent>

--- a/web/src/components/WhatsNew.tsx
+++ b/web/src/components/WhatsNew.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+import { CURRENT_VERSION, type Release, releasesSince } from "@/lib/releases";
+import { ReleaseEntry } from "@/components/ChangelogDialog";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+// Per-device record of the last version this browser saw the app at.
+const SEEN_KEY = "taskrr-seen-version";
+
+function readSeen(): string | null {
+  try {
+    return localStorage.getItem(SEEN_KEY);
+  } catch {
+    return null;
+  }
+}
+function writeSeen(v: string) {
+  try {
+    localStorage.setItem(SEEN_KEY, v);
+  } catch {
+    // storage unavailable — the dialog just won't suppress next time
+  }
+}
+
+/**
+ * WhatsNew shows a one-off dialog after the app updates: the changes since the
+ * version this browser last saw, with a single close. First-ever visit records
+ * the current version silently (nothing to announce). Renders nothing otherwise.
+ */
+export function WhatsNew() {
+  const [updates, setUpdates] = useState<Release[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const seen = readSeen();
+    if (!seen) {
+      writeSeen(CURRENT_VERSION);
+      return;
+    }
+    if (seen === CURRENT_VERSION) return;
+    const since = releasesSince(seen);
+    if (since.length === 0) {
+      writeSeen(CURRENT_VERSION); // moved versions but nothing recorded between
+      return;
+    }
+    setUpdates(since);
+    setOpen(true);
+  }, []);
+
+  const close = () => {
+    writeSeen(CURRENT_VERSION);
+    setOpen(false);
+  };
+
+  if (updates.length === 0) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && close()}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>What's new in v{CURRENT_VERSION}</DialogTitle>
+        </DialogHeader>
+        <div className="-mr-2 max-h-[60vh] space-y-5 overflow-y-auto pr-2">
+          {updates.map((r) => (
+            <ReleaseEntry key={r.version} release={r} />
+          ))}
+        </div>
+        <DialogFooter>
+          <Button onClick={close}>Got it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/settings/AccountSection.tsx
+++ b/web/src/components/settings/AccountSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ChevronRight, KeyRound, Link2, Link2Off, Trash2, UserRound } from "lucide-react";
+import { AlertTriangle, ChevronRight, KeyRound, Link2, Link2Off, Trash2, UserRound, Users } from "lucide-react";
 
 import { api } from "@/lib/api";
 import { clearStoredPreferences } from "@/lib/prefs";
@@ -82,6 +82,16 @@ export function AccountSection() {
     onError: (e) => setErr((e as Error).message),
   });
 
+  // Per-user opt-out for receiving shared tasks (shown only when sharing is on).
+  const allowShares = useMutation({
+    mutationFn: (allow: boolean) => api.setAllowShares(allow),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["me"], updated);
+      toast("Sharing preference saved", { tone: "success" });
+    },
+    onError: (e) => toast((e as Error).message, { tone: "error" }),
+  });
+
   const submit = () => {
     setErr(null);
     if (next.length < 8) return setErr("Password must be at least 8 characters.");
@@ -121,6 +131,27 @@ export function AccountSection() {
         {rename.isError && <p className="text-xs text-destructive">{(rename.error as Error).message}</p>}
         {rename.isSuccess && <p className="text-xs text-emerald-500">Username updated.</p>}
       </section>
+
+      {config?.tasksShareable && (
+        <section className="space-y-2">
+          <h4 className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
+            <Users className="h-3.5 w-3.5" /> Sharing
+          </h4>
+          <label className="flex items-center justify-between gap-2 text-sm">
+            <span className="text-muted-foreground">
+              Let others share tasks with me
+              <span className="block text-xs">When off, people can't send you tasks.</span>
+            </span>
+            <input
+              type="checkbox"
+              className="h-4 w-4 accent-primary"
+              checked={user?.allowShares ?? true}
+              disabled={allowShares.isPending}
+              onChange={(e) => allowShares.mutate(e.target.checked)}
+            />
+          </label>
+        </section>
+      )}
 
       <section className="space-y-2">
         <h4 className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">

--- a/web/src/components/ui/FolderInput.tsx
+++ b/web/src/components/ui/FolderInput.tsx
@@ -1,0 +1,35 @@
+import { useId } from "react";
+
+import { Input } from "@/components/ui/input";
+
+/**
+ * FolderInput is a plain text field for a task's folder, with a datalist of
+ * existing folder names so it's easy to reuse one (or type a new one).
+ */
+export function FolderInput({
+  value,
+  onChange,
+  suggestions = [],
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  suggestions?: string[];
+}) {
+  const listId = useId();
+  return (
+    <>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="No folder"
+        list={listId}
+        autoComplete="off"
+      />
+      <datalist id={listId}>
+        {suggestions.map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+    </>
+  );
+}

--- a/web/src/components/ui/TagInput.tsx
+++ b/web/src/components/ui/TagInput.tsx
@@ -1,0 +1,65 @@
+import { type KeyboardEvent, useState } from "react";
+import { X } from "lucide-react";
+
+/**
+ * TagInput is a small chip editor: existing tags show as removable chips, and a
+ * text field adds new ones (Enter or comma commits; Backspace on an empty field
+ * removes the last). Duplicates (case-insensitive) are ignored.
+ */
+export function TagInput({
+  value,
+  onChange,
+  placeholder = "Add a tag",
+}: {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const add = (raw: string) => {
+    const t = raw.trim();
+    setDraft("");
+    if (!t || value.some((v) => v.toLowerCase() === t.toLowerCase())) return;
+    onChange([...value, t]);
+  };
+  const remove = (tag: string) => onChange(value.filter((v) => v !== tag));
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      add(draft);
+    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+      remove(value[value.length - 1]);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent px-2 py-1.5 text-sm shadow-sm focus-within:ring-2 focus-within:ring-ring">
+      {value.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground"
+        >
+          {tag}
+          <button
+            type="button"
+            aria-label={`Remove ${tag}`}
+            onClick={() => remove(tag)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => add(draft)}
+        placeholder={value.length === 0 ? placeholder : ""}
+        className="min-w-[6rem] flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+      />
+    </div>
+  );
+}

--- a/web/src/lib/api.demo.ts
+++ b/web/src/lib/api.demo.ts
@@ -44,6 +44,8 @@ interface StoredTask {
   colorFresh: string | null;
   colorOverdue: string | null;
   freezeColor: boolean;
+  tags: string[];
+  folder: string;
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -97,6 +99,8 @@ interface SeedTask {
   colorFresh?: string | null;
   colorOverdue?: string | null;
   archived?: boolean;
+  tags?: string[];
+  folder?: string;
   /** Completion ages in seconds-ago, newest first. */
   log: number[];
   /** Optional notes keyed by index into `log`. */
@@ -110,24 +114,30 @@ const SEED: SeedTask[] = [
     name: "Water the plants",
     description: "The big ones by the window get thirsty fast.",
     intervalSeconds: 3 * DAY,
+    tags: ["plants", "home"],
+    folder: "Home",
     log: [2 * DAY + 4 * HOUR, 5 * DAY, 8 * DAY, 11 * DAY, 15 * DAY, 18 * DAY, 22 * DAY, 27 * DAY],
     notes: { 2: "skipped the succulents" },
   },
   {
     name: "Change bed sheets",
     intervalSeconds: 7 * DAY,
+    folder: "Home",
     log: [20 * HOUR, 7 * DAY, 14 * DAY, 22 * DAY, 30 * DAY],
   },
   {
     name: "Clean the litter box",
     description: "Scoop daily, full change weekly.",
     intervalSeconds: 1 * DAY,
+    tags: ["pets"],
     log: [2 * DAY + 2 * HOUR, 3 * DAY, 4 * DAY, 5 * DAY, 6 * DAY, 7 * DAY, 8 * DAY, 9 * DAY, 10 * DAY],
   },
   {
     name: "Back up the NAS",
     description: "Pull a fresh snapshot to the offsite drive.",
     intervalSeconds: 14 * DAY,
+    tags: ["tech"],
+    folder: "Tech",
     log: [3 * DAY, 17 * DAY, 32 * DAY, 47 * DAY],
     notes: { 0: "all volumes verified" },
   },
@@ -145,18 +155,22 @@ const SEED: SeedTask[] = [
     name: "Call grandma",
     description: "She likes Sunday afternoons.",
     intervalSeconds: 14 * DAY,
+    tags: ["family"],
     log: [10 * DAY, 24 * DAY, 39 * DAY],
     notes: { 0: "told her about the new job" },
   },
   {
     name: "Descale the coffee machine",
     intervalSeconds: 60 * DAY,
+    folder: "Home",
     log: [70 * DAY, 132 * DAY],
   },
   {
     name: "Water the herb garden",
     description: "Basil sulks if it dries out.",
     intervalSeconds: 2 * DAY,
+    tags: ["plants"],
+    folder: "Home",
     freezeColor: true,
     colorFresh: "#10b981",
     log: [18 * HOUR, 2 * DAY + 6 * HOUR, 4 * DAY, 6 * DAY, 9 * DAY, 12 * DAY],
@@ -199,6 +213,8 @@ function seed(): DB {
       colorFresh: s.colorFresh ?? null,
       colorOverdue: s.colorOverdue ?? null,
       freezeColor: s.freezeColor ?? false,
+      tags: s.tags ?? [],
+      folder: s.folder ?? "",
       archivedAt: s.archived ? iso(oldest + DAY) : null,
       createdAt: iso(oldest + 2 * DAY),
       updatedAt: iso(oldest + 2 * DAY),
@@ -233,16 +249,22 @@ function toTask(db: DB, t: StoredTask): Task {
     colorFresh: t.colorFresh,
     colorOverdue: t.colorOverdue,
     freezeColor: t.freezeColor,
+    tags: t.tags ?? [],
+    folder: t.folder ?? "",
     archivedAt: t.archivedAt,
     createdAt: t.createdAt,
     updatedAt: t.updatedAt,
     lastCompletedAt: last,
     completionCount: mine.length,
+    // The demo is single-user: nothing is ever shared.
+    ownerId: 1,
+    shared: false,
+    lastCompletedBy: null,
   };
 }
 
 function toCompletion(c: StoredCompletion): Completion {
-  return { id: c.id, taskId: c.taskId, completedAt: c.completedAt, note: c.note, createdAt: c.createdAt };
+  return { id: c.id, taskId: c.taskId, userId: 1, completedAt: c.completedAt, note: c.note, createdAt: c.createdAt };
 }
 
 function findTask(db: DB, id: number): StoredTask {
@@ -271,6 +293,7 @@ function demoUser(): User {
     passwordSet: true,
     oidcLinked: false,
     protected: false,
+    allowShares: true,
     createdAt: iso(120 * DAY),
     updatedAt: iso(120 * DAY),
   };
@@ -303,6 +326,7 @@ const DEMO_AUTH: AuthConfig = {
   defaultThemeEnforce: false,
   themesShareable: false,
   themesShareUsers: false,
+  tasksShareable: false,
   branding: {
     name: "Taskrr",
     title: "",
@@ -339,6 +363,8 @@ export const demoApi: Api = {
       colorFresh: input.colorFresh ?? null,
       colorOverdue: input.colorOverdue ?? null,
       freezeColor: input.freezeColor ?? false,
+      tags: input.tags ?? [],
+      folder: input.folder ?? "",
       archivedAt: null,
       createdAt: now,
       updatedAt: now,
@@ -357,6 +383,8 @@ export const demoApi: Api = {
     if (input.colorFresh !== undefined) t.colorFresh = input.colorFresh;
     if (input.colorOverdue !== undefined) t.colorOverdue = input.colorOverdue;
     if (input.freezeColor !== undefined) t.freezeColor = input.freezeColor;
+    if (input.tags !== undefined) t.tags = input.tags;
+    if (input.folder !== undefined) t.folder = input.folder;
     t.updatedAt = new Date().toISOString();
     saveDB(db);
     return tick(toTask(db, t));
@@ -445,6 +473,17 @@ export const demoApi: Api = {
       }));
     return tick(rows);
   },
+
+  // --- shared tasks (the demo is single-user, so sharing is hidden/empty) ---
+  shareTask: notAvailable,
+  respondShare: notAvailable,
+  leaveTask: notAvailable,
+  listMembers: () => tick([]),
+  listIncomingShares: () => tick([]),
+  setAllowShares: () => tick(demoUser()),
+
+  // No server in the demo, so there's nothing to check against.
+  checkLatestVersion: () => tick({ latest: "" }),
 
   // --- auth ---
   authConfig: () => tick(DEMO_AUTH),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,20 +21,58 @@ export interface Task {
   colorOverdue: string | null;
   /** Pin the staleness colour to "fresh" (a visual "stay green" preference). */
   freezeColor: boolean;
+  /** Short user labels for filtering and grouping. */
+  tags: string[];
+  /** Optional single group name; empty means ungrouped. */
+  folder: string;
   /** Non-null when the task is soft-archived (hidden from the normal views). */
   archivedAt: string | null;
   createdAt: string;
   updatedAt: string;
   lastCompletedAt: string | null;
   completionCount: number;
+  /** The account that owns the task; compare to the current user to tell owner
+   *  from member (members may log + leave; the owner edits/archives). */
+  ownerId: number;
+  /** True when the task has members (shared by the owner, or shared with you). */
+  shared: boolean;
+  /** Username of whoever logged the most recent completion, or null. */
+  lastCompletedBy: string | null;
 }
 
 export interface Completion {
   id: number;
   taskId: number;
+  /** Who logged this completion (null only for history whose author was removed). */
+  userId: number | null;
   completedAt: string;
   note: string;
   createdAt: string;
+}
+
+/** A membership row: an extra user attached to a task. */
+export interface TaskShare {
+  taskId: number;
+  userId: number;
+  status: "pending" | "accepted";
+  createdAt: string;
+}
+
+/** A pending incoming share, named for the recipient's Requests view. */
+export interface ShareRequest {
+  taskId: number;
+  taskName: string;
+  ownerId: number;
+  ownerName: string;
+  createdAt: string;
+}
+
+/** One participant in a task: the owner, or a shared member with their status. */
+export interface TaskMember {
+  userId: number;
+  username: string;
+  /** "owner" for the task's owner, else the share status. */
+  status: "owner" | "pending" | "accepted";
 }
 
 /** A completion joined with its task name — the flat feed the calendar uses. */
@@ -57,6 +95,8 @@ export interface User {
   oidcLinked: boolean;
   /** The bootstrap admin — other admins can't edit/delete it. */
   protected: boolean;
+  /** Whether this user accepts having tasks shared with them (opt-out). */
+  allowShares: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -92,6 +132,8 @@ export interface AuthConfig {
   themesShareable: boolean;
   /** Regular users (not just admins) may publish themes too. */
   themesShareUsers: boolean;
+  /** Admin gate for the whole shared-tasks feature. */
+  tasksShareable: boolean;
   /** Instance branding (name, title, icon, login toggles). */
   branding: Branding;
 }
@@ -170,6 +212,7 @@ export interface AdminSettings {
   default_theme_enforce: boolean;
   themes_shareable: boolean;
   themes_share_users: boolean;
+  tasks_shareable: boolean;
   brand_name: string;
   brand_title: string;
   brand_tagline: string;
@@ -194,6 +237,7 @@ export type SettingsPatch = Partial<{
   default_theme_enforce: boolean;
   themes_shareable: boolean;
   themes_share_users: boolean;
+  tasks_shareable: boolean;
   brand_name: string;
   brand_title: string;
   brand_tagline: string;
@@ -213,6 +257,10 @@ export interface TaskInput {
   colorOverdue?: string | null;
   /** Pin the staleness colour to "fresh". */
   freezeColor?: boolean;
+  /** Short labels for filtering and grouping (server trims/dedupes/caps). */
+  tags?: string[];
+  /** Optional single group name (empty = ungrouped). */
+  folder?: string;
 }
 
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
@@ -291,6 +339,42 @@ const httpApi = {
     request<Activity[]>(
       `/api/activity?from=${encodeURIComponent(fromISO)}&to=${encodeURIComponent(toISO)}`,
     ),
+
+  // --- shared tasks ---
+
+  /** Owner invites a user (by username) to a task; creates a pending share. */
+  shareTask: (taskId: number, username: string) =>
+    request<TaskShare>(`/api/tasks/${taskId}/share`, {
+      method: "POST",
+      body: JSON.stringify({ username }),
+    }),
+
+  /** Accept or decline a pending incoming share for the current user. */
+  respondShare: (taskId: number, accept: boolean) =>
+    request<void>(`/api/tasks/${taskId}/share/respond`, {
+      method: "POST",
+      body: JSON.stringify({ accept }),
+    }),
+
+  /** Leave a shared task (a member removes their own membership). */
+  leaveTask: (taskId: number) =>
+    request<void>(`/api/tasks/${taskId}/leave`, { method: "POST" }),
+
+  /** Everyone attached to a task: owner + members. */
+  listMembers: (taskId: number) => request<TaskMember[]>(`/api/tasks/${taskId}/members`),
+
+  /** The current user's pending incoming shares (their Requests view). */
+  listIncomingShares: () => request<ShareRequest[]>("/api/me/shares"),
+
+  /** Set whether others may share tasks with the current user (opt-out). */
+  setAllowShares: (allowShares: boolean) =>
+    request<User>("/api/me/allow-shares", {
+      method: "PUT",
+      body: JSON.stringify({ allowShares }),
+    }),
+
+  /** Latest released version (informational; "" if checking is disabled/unreachable). */
+  checkLatestVersion: () => request<{ latest: string }>("/api/version/latest"),
 
   // --- auth ---
 

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -5,7 +5,14 @@
 import type { Task } from "./api";
 import { taskStaleness } from "./staleness";
 
-export type Filter = "all" | "due-soon" | "overdue" | "none" | "archived";
+export type Filter =
+  | "all"
+  | "due-soon"
+  | "overdue"
+  | "none"
+  | "archived"
+  | "shared"
+  | "requests";
 
 export const FILTERS: { key: Filter; label: string }[] = [
   { key: "all", label: "All tasks" },
@@ -15,13 +22,24 @@ export const FILTERS: { key: Filter; label: string }[] = [
   { key: "archived", label: "Archived" },
 ];
 
+/** Extra views shown only when task sharing is enabled. "shared" groups tasks
+ *  with collaborators; "requests" is not a task filter — the app renders its own
+ *  list of incoming invites — so callers gate it specially. */
+export const SHARE_FILTERS: { key: Filter; label: string }[] = [
+  { key: "shared", label: "Shared" },
+  { key: "requests", label: "Requests" },
+];
+
 /**
  * Whether a task belongs in the given view at the given moment. Archived tasks
  * only appear in the "Archived" view; every other view is active-tasks-only.
+ * "requests" never matches a task here (the app renders incoming invites for it).
  */
 export function matchesFilter(task: Task, filter: Filter, now?: number): boolean {
+  if (filter === "requests") return false;
   if (filter === "archived") return task.archivedAt != null;
   if (task.archivedAt != null) return false;
   if (filter === "all") return true;
+  if (filter === "shared") return task.shared;
   return taskStaleness(task, now) === filter;
 }

--- a/web/src/lib/folders.ts
+++ b/web/src/lib/folders.ts
@@ -1,0 +1,8 @@
+import type { Task } from "./api";
+
+/** Distinct, alphabetically-sorted folder names across the given tasks. */
+export function folderNames(tasks: Task[]): string[] {
+  const set = new Set<string>();
+  for (const t of tasks) if (t.folder) set.add(t.folder);
+  return [...set].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+}

--- a/web/src/lib/prefs.tsx
+++ b/web/src/lib/prefs.tsx
@@ -19,6 +19,7 @@ import {
 import { installSmoothWheel } from "@/lib/smoothScroll";
 import { setTimeFormat } from "@/lib/time";
 import { type Theme } from "@/lib/theme";
+import { type SortKey } from "@/lib/sort";
 
 export type ColorPickerStyle = "wheel" | "native";
 export type AddButtonPosition = "top" | "bottom";
@@ -56,6 +57,10 @@ export interface Prefs {
   // --- layout ---
   /** Task card density. */
   cardSize: CardSize;
+  /** How the task list is ordered (see lib/sort.ts). */
+  sortBy: SortKey;
+  /** Group the task list into collapsible sections by folder. */
+  groupByFolder: boolean;
   /** Fixed number of task columns, or 0 for the responsive default. */
   taskColumns: number;
   /** Show the calendar / activity-chart side panels. */
@@ -138,6 +143,8 @@ function defaults(): Prefs {
     colorFade: true,
     addButton: "top",
     cardSize: "comfortable",
+    sortBy: "smart",
+    groupByFolder: false,
     taskColumns: 0,
     showCalendar: true,
     showActivity: true,

--- a/web/src/lib/releases.test.ts
+++ b/web/src/lib/releases.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import pkg from "../../package.json";
+import { compareVersions, RELEASES, releasesSince } from "@/lib/releases";
+
+const LATEST = RELEASES[0].version;
+
+describe("releases data", () => {
+  it("lists the app's version first (forces a changelog entry on every bump)", () => {
+    expect(RELEASES[0].version).toBe(pkg.version);
+  });
+
+  it("is sorted strictly newest-first", () => {
+    for (let i = 1; i < RELEASES.length; i++) {
+      expect(compareVersions(RELEASES[i - 1].version, RELEASES[i].version)).toBeGreaterThan(0);
+    }
+  });
+
+  it("has at least one non-empty change per release", () => {
+    for (const r of RELEASES) {
+      expect(r.changes.length).toBeGreaterThan(0);
+      for (const c of r.changes) expect(c.text.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders by major, then minor, then patch", () => {
+    expect(compareVersions("1.10.0", "1.9.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.10.1", "1.10.0")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
+    expect(compareVersions("1.13.0", "1.13.0")).toBe(0);
+    expect(compareVersions("1.9.0", "1.10.0")).toBeLessThan(0);
+  });
+});
+
+describe("releasesSince", () => {
+  it("returns every release strictly newer than the seen version, across gaps", () => {
+    // Updating from the oldest recorded release shows everything since, newest first.
+    const oldest = RELEASES[RELEASES.length - 1].version;
+    const since = releasesSince(oldest).map((r) => r.version);
+    expect(since).toHaveLength(RELEASES.length - 1);
+    expect(since[0]).toBe(LATEST);
+    expect(since).not.toContain(oldest);
+    // From any mid-history version, every result is strictly newer.
+    const mid = RELEASES[Math.floor(RELEASES.length / 2)].version;
+    expect(releasesSince(mid).every((r) => compareVersions(r.version, mid) > 0)).toBe(true);
+  });
+
+  it("is empty when the seen version is current or ahead", () => {
+    expect(releasesSince(LATEST)).toHaveLength(0);
+    expect(releasesSince("99.0.0")).toHaveLength(0);
+  });
+});

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -1,0 +1,209 @@
+// releases.ts — the in-app changelog data. Kept terse and curated (separate
+// from the developer CHANGELOG.md) so the version menu and the post-update
+// "what's new" dialog can render it with per-change icons.
+//
+// To add a release: bump the version in web/package.json and prepend one entry
+// to RELEASES below. That is the only maintenance step — releases.test.ts fails
+// if the top entry does not match the current version, so it can't be forgotten,
+// and the what's-new dialog derives "changes since version X" from this list
+// (any gap, e.g. 1.10.1 -> 1.15.7, shows every release in between).
+
+declare const __APP_VERSION__: string;
+
+export type ChangeKind = "feature" | "fix";
+
+export interface Change {
+  text: string;
+  kind: ChangeKind;
+  /** Optional grey explanation shown after the change as "- ...". */
+  note?: string;
+}
+
+export interface Release {
+  version: string;
+  /** ISO date (YYYY-MM-DD). */
+  date: string;
+  changes: Change[];
+}
+
+// `typeof` guard so this never throws if the define is absent (e.g. a test
+// runner without Vite's replacement); the real build always substitutes it.
+export const CURRENT_VERSION: string =
+  typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";
+
+const feat = (text: string, note?: string): Change => ({ text, kind: "feature", note });
+const fix = (text: string, note?: string): Change => ({ text, kind: "fix", note });
+
+// Newest first. Keep the headline short; put the explanation in the note.
+export const RELEASES: Release[] = [
+  {
+    version: "1.11.0",
+    date: "2026-06-15",
+    changes: [
+      feat(
+        "Shared tasks",
+        "Share a task with another user so you both see and log it, with who-logged-last tracked. Owners invite by username; members can leave. Admins enable it under Admin settings.",
+      ),
+      feat(
+        "Requests and opt-out",
+        "Incoming shares wait under a Requests view to accept or decline, and you can opt out of receiving shares in your account settings.",
+      ),
+      feat(
+        "Tags",
+        "Label a task with one or more tags, then click a tag chip (or use search) to filter the list. Manage tags in the task's dialog.",
+      ),
+      feat("Search", "A search box filters tasks by name, description, or tag as you type."),
+      feat("Sorting", "Order the list by name, most or least recently done, or newest, from the toolbar."),
+      feat(
+        "Folders",
+        "Give a task a folder, then turn on Group in the toolbar to collapse the list into a section per folder.",
+      ),
+      feat(
+        "In-app changelog",
+        "The version number in the sidebar opens this changelog and shows each release's date.",
+      ),
+      feat(
+        "What's new on update",
+        "After an update you get a one-off summary of everything that changed since you last opened the app.",
+      ),
+      feat(
+        "Update check",
+        "Admins can check whether a newer version has been released. It only reports what's available and never updates the app itself.",
+      ),
+    ],
+  },
+  {
+    version: "1.10.0",
+    date: "2026-06-14",
+    changes: [
+      feat(
+        "Instance branding",
+        "Admins can set the app's name, browser-tab title, tagline, and icon under Admin settings.",
+      ),
+    ],
+  },
+  {
+    version: "1.9.0",
+    date: "2026-06-14",
+    changes: [
+      feat("Toasts", "Brief confirmations appear for common actions; turn them off in your preferences."),
+    ],
+  },
+  {
+    version: "1.8.0",
+    date: "2026-06-14",
+    changes: [
+      feat("Calendar month/year picker", "Jump the calendar to any month or year from its header."),
+      feat("User theme sharing", "Admins can let regular users publish their saved themes to everyone, not just admins."),
+    ],
+  },
+  {
+    version: "1.7.0",
+    date: "2026-06-13",
+    changes: [
+      feat(
+        "Custom date picker",
+        "A built-in date and time picker, with its own preferences, used when logging or editing completions.",
+      ),
+      feat("Pop-out logs", "Admins can pop the server log view out into its own window."),
+      feat(
+        "Colour-fade toggle",
+        "Turn off a task's fade to overdue when you only care that it was done, not how long ago.",
+      ),
+    ],
+  },
+  {
+    version: "1.6.0",
+    date: "2026-06-13",
+    changes: [
+      feat("Per-account themes", "Your theme follows your account across devices, and admins can force a default for everyone."),
+      fix("Theme kept on logout", "Signing out no longer discards your customised theme."),
+    ],
+  },
+  {
+    version: "1.5.0",
+    date: "2026-06-13",
+    changes: [
+      feat(
+        "Safety backups",
+        "A backup is taken automatically just before a restore, so a mistaken restore can be undone. Toggle it with TASKRR_SAFETY_BACKUP.",
+      ),
+      feat("Versioned images", "Container images are published per release, not just as latest."),
+    ],
+  },
+  {
+    version: "1.4.0",
+    date: "2026-06-12",
+    changes: [
+      feat("OIDC-only sign-in", "Admins can require single sign-on and hide the password login."),
+      feat("Wipe everything", "A true reset that clears all data while keeping the acting admin signed in."),
+    ],
+  },
+  {
+    version: "1.3.0",
+    date: "2026-06-12",
+    changes: [
+      feat(
+        "Encrypted OIDC secret",
+        "The OIDC client secret is encrypted at rest when TASKRR_SECRET_KEY is set, so it isn't stored or backed up in plaintext.",
+      ),
+      feat("HSTS behind TLS", "The server sends HSTS when served over HTTPS through a trusted proxy."),
+    ],
+  },
+  {
+    version: "1.2.0",
+    date: "2026-06-11",
+    changes: [feat("Follows your clock", "Time and date formatting follow your device's locale by default.")],
+  },
+  {
+    version: "1.1.0",
+    date: "2026-06-11",
+    changes: [
+      feat(
+        "Browser demo",
+        "A no-backend demo of the whole app that runs entirely in your browser, behind the public demo site.",
+      ),
+    ],
+  },
+  {
+    version: "1.0.0",
+    date: "2026-06-11",
+    changes: [
+      feat(
+        "First public release",
+        "Last-done tracking with routines, a calendar, multiple users, OIDC, backups, reminders, and a themeable UI.",
+      ),
+    ],
+  },
+];
+
+function parts(v: string): number[] {
+  return v.split(".").map((n) => parseInt(n, 10) || 0);
+}
+
+/** Negative if a < b, zero if equal, positive if a > b. */
+export function compareVersions(a: string, b: string): number {
+  const pa = parts(a);
+  const pb = parts(b);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+export function currentRelease(): Release | undefined {
+  return RELEASES.find((r) => r.version === CURRENT_VERSION);
+}
+
+/** Releases strictly newer than `version` (drives the what's-new dialog). */
+export function releasesSince(version: string): Release[] {
+  return RELEASES.filter((r) => compareVersions(r.version, version) > 0);
+}
+
+/** Format an ISO release date for display (parsed as local midnight). */
+export function formatReleaseDate(date: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return date;
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}

--- a/web/src/lib/sort.ts
+++ b/web/src/lib/sort.ts
@@ -1,0 +1,44 @@
+// sort.ts — how the task list is ordered. Kept here (like filters.ts) so the
+// ordering policy lives in one tunable place next to the UI.
+
+import type { Task } from "./api";
+
+export type SortKey = "smart" | "name" | "recent" | "stale" | "created";
+
+export const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: "smart", label: "Recommended" },
+  { key: "name", label: "Name (A-Z)" },
+  { key: "recent", label: "Recently done" },
+  { key: "stale", label: "Least recently done" },
+  { key: "created", label: "Newest" },
+];
+
+function lastDone(t: Task): number {
+  return t.lastCompletedAt ? Date.parse(t.lastCompletedAt) : 0;
+}
+
+/**
+ * Return a new array ordered by the chosen key. "smart" keeps the server order
+ * (most actionable first), so it is a stable copy with no reordering.
+ */
+export function sortTasks(tasks: Task[], key: SortKey): Task[] {
+  const out = [...tasks];
+  switch (key) {
+    case "name":
+      out.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+      break;
+    case "recent":
+      out.sort((a, b) => lastDone(b) - lastDone(a));
+      break;
+    case "stale":
+      out.sort((a, b) => lastDone(a) - lastDone(b));
+      break;
+    case "created":
+      out.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+      break;
+    case "smart":
+    default:
+      break;
+  }
+  return out;
+}

--- a/web/src/lib/staleness.test.ts
+++ b/web/src/lib/staleness.test.ts
@@ -13,11 +13,16 @@ function task(partial: Partial<Task>): Task {
     colorFresh: null,
     colorOverdue: null,
     freezeColor: false,
+    tags: [],
+    folder: "",
     archivedAt: null,
     createdAt: "",
     updatedAt: "",
     lastCompletedAt: null,
     completionCount: 0,
+    ownerId: 1,
+    shared: false,
+    lastCompletedBy: null,
     ...partial,
   };
 }


### PR DESCRIPTION
## Summary

Three feature areas, plus the schema and configuration to support them.

### Shared tasks
Share a task with another user so both see and log it. Admin-gated by a **Task sharing** instance setting (hidden and refused when off).

- Owners invite by username; the invite waits as a pending request.
- Recipients accept or decline from a **Requests** view, which shows a calm accent pulse when something is waiting. Users can opt out of receiving shares in account settings.
- Members can view, log, and leave; the owner edits and archives the definition.
- Each completion records who logged it; the card shows who logged last.
- Deletion is non-destructive for collaborators: a member who deletes simply leaves, and when an owner deletes a task that still has members, ownership transfers to the earliest member so the task and its full history are never lost.

### Organisation
- **Tags** with a search box and clickable tag chips to filter the list.
- **Folders** with an optional grouping mode that collapses the list into a section per folder.
- **Sorting** by name or most/least recently done, from the toolbar.

### Changelog & version
- The version label opens an in-app changelog.
- A "what's new" dialog summarises changes after an update.
- An admin-only, server-side "check for updates" reports the latest released version (`TASKRR_UPDATE_CHECK_URL`); it is informational only and never auto-updates.

## Data & config
- Migrations `0010`–`0012`: `task_shares`, `completions.user_id`, `users.allow_shares`, `tasks.tags`, `tasks.folder`.
- New settings: `tasks_shareable` (admin) and `TASKRR_UPDATE_CHECK_URL` (env).
- `README.md` and `.env.example` updated.

## Authorisation
Task and completion access is scoped to "owner or accepted member" throughout; updating/archiving the definition stays owner-only, and editing a completion is limited to the task owner or the entry's author. The share opt-out is enforced server-side, and the update-check endpoint is admin-only.

## Testing
- Go: `go vet` and the full suite pass, including new coverage for share authorisation and lifecycle (invite/accept/decline/leave), owner-delete transfer, account deletion/merge reassignment, tag normalisation, and the version endpoint.
- Frontend: typecheck, unit tests, and production build pass.
- The static demo build is unaffected; sharing is hidden there (no second user/server).