### PR TITLE
Reminders for shared members; shared badge only on accepted shares

### DIFF
--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -34,7 +34,7 @@ import (
 // Store is the slice of the data layer the reminder loop needs.
 type Store interface {
 	ListReminderCandidates(ctx context.Context) ([]store.ReminderCandidate, error)
-	MarkReminded(ctx context.Context, taskID int64, dueAt time.Time) error
+	MarkReminded(ctx context.Context, taskID, userID int64, dueAt time.Time) error
 }
 
 // Service evaluates and delivers reminders.
@@ -135,7 +135,7 @@ func (s *Service) Tick(ctx context.Context) {
 			log.Printf("reminder: task %d webhook failed: %v", c.TaskID, err)
 			continue // leave un-marked so it retries next tick
 		}
-		if err := s.store.MarkReminded(ctx, c.TaskID, due); err != nil {
+		if err := s.store.MarkReminded(ctx, c.TaskID, c.UserID, due); err != nil {
 			log.Printf("reminder: mark task %d reminded: %v", c.TaskID, err)
 		}
 	}

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -18,28 +18,34 @@ func testService(st Store) *Service {
 	return &Service{store: st, client: newHTTPClient(func(net.IP) bool { return false })}
 }
 
+// markKey dedups reminders per (task, recipient), mirroring the real store.
+type markKey struct {
+	task int64
+	user int64
+}
+
 // fakeStore is an in-memory Store for exercising Tick without a database.
 type fakeStore struct {
 	cands  []store.ReminderCandidate
-	marked map[int64]time.Time
+	marked map[markKey]time.Time
 }
 
 func (f *fakeStore) ListReminderCandidates(context.Context) ([]store.ReminderCandidate, error) {
 	out := make([]store.ReminderCandidate, len(f.cands))
 	copy(out, f.cands)
 	for i := range out {
-		if due, ok := f.marked[out[i].TaskID]; ok {
+		if due, ok := f.marked[markKey{out[i].TaskID, out[i].UserID}]; ok {
 			out[i].LastRemindedDue = due.UTC().Format(time.RFC3339)
 		}
 	}
 	return out, nil
 }
 
-func (f *fakeStore) MarkReminded(_ context.Context, taskID int64, dueAt time.Time) error {
+func (f *fakeStore) MarkReminded(_ context.Context, taskID, userID int64, dueAt time.Time) error {
 	if f.marked == nil {
-		f.marked = map[int64]time.Time{}
+		f.marked = map[markKey]time.Time{}
 	}
-	f.marked[taskID] = dueAt
+	f.marked[markKey{taskID, userID}] = dueAt
 	return nil
 }
 
@@ -134,7 +140,7 @@ func TestSendRejectsLoopback(t *testing.T) {
 		t.Fatalf("loopback webhook should have been blocked, but server was hit %d time(s)", got)
 	}
 	// A blocked delivery is not marked, so it isn't silently considered "done".
-	if _, ok := fs.marked[9]; ok {
+	if _, ok := fs.marked[markKey{9, 0}]; ok {
 		t.Fatal("a blocked delivery must not be marked as reminded")
 	}
 }

--- a/internal/store/migrations/0013_reminders_per_user.sql
+++ b/internal/store/migrations/0013_reminders_per_user.sql
@@ -1,0 +1,23 @@
+-- Reminders become per-recipient. A task can now be shared, and each member who
+-- has reminders enabled should get their own reminder. The once-per-cycle dedup
+-- therefore moves from being keyed by task_id alone to (task_id, user_id).
+--
+-- Existing dedup rows belonged to the task's owner (reminders were owner-only
+-- before sharing), so they're carried over attributed to the current owner.
+
+ALTER TABLE task_reminders RENAME TO task_reminders_old;
+
+CREATE TABLE task_reminders (
+    task_id INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    due_at  TEXT NOT NULL,
+    sent_at TEXT NOT NULL,
+    PRIMARY KEY (task_id, user_id)
+);
+
+INSERT INTO task_reminders (task_id, user_id, due_at, sent_at)
+    SELECT o.task_id, t.owner_id, o.due_at, o.sent_at
+    FROM task_reminders_old o
+    JOIN tasks t ON t.id = o.task_id;
+
+DROP TABLE task_reminders_old;

--- a/internal/store/reminders.go
+++ b/internal/store/reminders.go
@@ -54,32 +54,42 @@ func (s *Store) SetReminderSettings(ctx context.Context, userID int64, rs Remind
 	return err
 }
 
-// ReminderCandidate is a due-eligible task joined with its owner's webhook config
-// and the due-time it was last reminded for. Due-ness and once-per-cycle dedup
-// are decided by the caller (in Go), mirroring the frontend's nextDue logic.
+// ReminderCandidate is a due-eligible task paired with one recipient's webhook
+// config and the due-time that recipient was last reminded for. A shared task
+// yields one candidate per enabled recipient (owner + accepted members).
+// Due-ness and once-per-cycle dedup are decided by the caller (in Go),
+// mirroring the frontend's nextDue logic.
 type ReminderCandidate struct {
 	TaskID        int64
 	OwnerID       int64
+	UserID        int64 // the recipient to notify (owner or an accepted member)
 	TaskName      string
 	IntervalSecs  int64
 	WebhookURL    string
 	LeadSeconds   int64
 	LastCompleted time.Time
-	// LastRemindedDue is the RFC3339 dueAt we last reminded for, or "" if never.
+	// LastRemindedDue is the RFC3339 dueAt we last reminded this recipient for,
+	// or "" if never.
 	LastRemindedDue string
 }
 
-// ListReminderCandidates returns every non-archived cadence task that has been
-// completed at least once and whose owner has reminders enabled with a webhook.
+// ListReminderCandidates returns, for every non-archived cadence task completed
+// at least once, one row per recipient (the owner or an accepted member) who has
+// reminders enabled with a webhook. Each recipient's last-reminded due-time is
+// looked up per (task, user) so collaborators are reminded independently.
 func (s *Store) ListReminderCandidates(ctx context.Context) ([]ReminderCandidate, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT t.id, t.owner_id, t.name, t.interval_seconds, rs.webhook_url, rs.lead_seconds,
+		SELECT t.id, t.owner_id, rs.user_id, t.name, t.interval_seconds, rs.webhook_url, rs.lead_seconds,
 		       (SELECT MAX(completed_at) FROM completions c WHERE c.task_id = t.id) AS last_completed_at,
-		       COALESCE((SELECT due_at FROM task_reminders tr WHERE tr.task_id = t.id), '') AS last_reminded_due
+		       COALESCE((SELECT due_at FROM task_reminders tr
+		                  WHERE tr.task_id = t.id AND tr.user_id = rs.user_id), '') AS last_reminded_due
 		FROM tasks t
-		JOIN reminder_settings rs ON rs.user_id = t.owner_id
-		WHERE rs.enabled = 1 AND TRIM(rs.webhook_url) <> ''
-		  AND t.archived_at IS NULL
+		JOIN reminder_settings rs
+		  ON rs.enabled = 1 AND TRIM(rs.webhook_url) <> ''
+		 AND (rs.user_id = t.owner_id
+		      OR EXISTS (SELECT 1 FROM task_shares sh
+		                  WHERE sh.task_id = t.id AND sh.user_id = rs.user_id AND sh.status = 'accepted'))
+		WHERE t.archived_at IS NULL
 		  AND t.interval_seconds IS NOT NULL AND t.interval_seconds > 0`)
 	if err != nil {
 		return nil, err
@@ -91,7 +101,7 @@ func (s *Store) ListReminderCandidates(ctx context.Context) ([]ReminderCandidate
 			c        ReminderCandidate
 			lastComp sql.NullString
 		)
-		if err := rows.Scan(&c.TaskID, &c.OwnerID, &c.TaskName, &c.IntervalSecs,
+		if err := rows.Scan(&c.TaskID, &c.OwnerID, &c.UserID, &c.TaskName, &c.IntervalSecs,
 			&c.WebhookURL, &c.LeadSeconds, &lastComp, &c.LastRemindedDue); err != nil {
 			return nil, err
 		}
@@ -104,13 +114,13 @@ func (s *Store) ListReminderCandidates(ctx context.Context) ([]ReminderCandidate
 	return out, rows.Err()
 }
 
-// MarkReminded records that a task was reminded for a given due-time, so the
-// same cycle won't fire again. Keyed by task, so it advances with each cycle.
-func (s *Store) MarkReminded(ctx context.Context, taskID int64, dueAt time.Time) error {
+// MarkReminded records that a recipient was reminded for a task's given due-time,
+// so the same cycle won't fire again for that recipient. Keyed by (task, user).
+func (s *Store) MarkReminded(ctx context.Context, taskID, userID int64, dueAt time.Time) error {
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO task_reminders (task_id, due_at, sent_at) VALUES (?, ?, ?)
-		 ON CONFLICT(task_id) DO UPDATE SET due_at = excluded.due_at, sent_at = excluded.sent_at`,
-		taskID, dueAt.UTC().Format(timeLayout), time.Now().UTC().Format(timeLayout),
+		`INSERT INTO task_reminders (task_id, user_id, due_at, sent_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(task_id, user_id) DO UPDATE SET due_at = excluded.due_at, sent_at = excluded.sent_at`,
+		taskID, userID, dueAt.UTC().Format(timeLayout), time.Now().UTC().Format(timeLayout),
 	)
 	return err
 }

--- a/internal/store/reminders_test.go
+++ b/internal/store/reminders_test.go
@@ -70,11 +70,71 @@ func TestListReminderCandidates(t *testing.T) {
 
 	// After marking reminded for the current due time, that due time is recorded.
 	dueAt := cands[0].LastCompleted.Add(time.Hour)
-	if err := st.MarkReminded(ctx, due.ID, dueAt); err != nil {
+	if err := st.MarkReminded(ctx, due.ID, cands[0].UserID, dueAt); err != nil {
 		t.Fatalf("MarkReminded: %v", err)
 	}
 	cands, _ = st.ListReminderCandidates(ctx)
 	if len(cands) != 1 || cands[0].LastRemindedDue != dueAt.UTC().Format(timeLayout) {
 		t.Fatalf("expected last_reminded_due recorded, got %+v", cands)
+	}
+}
+
+// TestReminderCandidatesIncludeSharedMembers: a task shared with (and accepted
+// by) another user who has reminders on yields a candidate for that member, with
+// per-recipient dedup independent of the owner.
+func TestReminderCandidatesIncludeSharedMembers(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, _ := st.CreateUser(ctx, UserInput{Username: "owner", Role: "user"})
+	member, _ := st.CreateUser(ctx, UserInput{Username: "member", Role: "user"})
+	other, _ := st.CreateUser(ctx, UserInput{Username: "other", Role: "user"})
+
+	// Owner and member have reminders on; "other" does not.
+	_ = st.SetReminderSettings(ctx, owner.ID, ReminderSettings{Enabled: true, WebhookURL: "https://h/owner"})
+	_ = st.SetReminderSettings(ctx, member.ID, ReminderSettings{Enabled: true, WebhookURL: "https://h/member"})
+
+	hourly := int64(3600)
+	task, _ := st.CreateTask(ctx, owner.ID, TaskInput{Name: "shared", IntervalSeconds: &hourly})
+	_, _ = st.AddCompletion(ctx, owner.ID, task.ID, time.Now().Add(-2*time.Hour), "")
+
+	// Pending share → member is not yet a candidate.
+	if _, err := st.ShareTask(ctx, owner.ID, task.ID, member.ID); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	// "other" is invited too but never accepts → never a candidate.
+	if _, err := st.ShareTask(ctx, owner.ID, task.ID, other.ID); err != nil {
+		t.Fatalf("ShareTask other: %v", err)
+	}
+	cands, _ := st.ListReminderCandidates(ctx)
+	if len(cands) != 1 || cands[0].UserID != owner.ID {
+		t.Fatalf("pending share should yield only the owner, got %+v", cands)
+	}
+
+	// Member accepts → now both owner and member are candidates.
+	if err := st.RespondToShare(ctx, member.ID, task.ID, true); err != nil {
+		t.Fatalf("RespondToShare: %v", err)
+	}
+	cands, _ = st.ListReminderCandidates(ctx)
+	byUser := map[int64]ReminderCandidate{}
+	for _, c := range cands {
+		byUser[c.UserID] = c
+	}
+	if len(cands) != 2 || byUser[owner.ID].WebhookURL != "https://h/owner" || byUser[member.ID].WebhookURL != "https://h/member" {
+		t.Fatalf("want owner+member candidates with their own webhooks, got %+v", cands)
+	}
+
+	// Marking the owner reminded does not suppress the member (per-recipient dedup).
+	dueAt := byUser[owner.ID].LastCompleted.Add(time.Hour)
+	if err := st.MarkReminded(ctx, task.ID, owner.ID, dueAt); err != nil {
+		t.Fatalf("MarkReminded: %v", err)
+	}
+	cands, _ = st.ListReminderCandidates(ctx)
+	for _, c := range cands {
+		if c.UserID == owner.ID && c.LastRemindedDue == "" {
+			t.Fatal("owner should be marked reminded")
+		}
+		if c.UserID == member.ID && c.LastRemindedDue != "" {
+			t.Fatal("member must still be pending (independent dedup)")
+		}
 	}
 }

--- a/internal/store/shares_test.go
+++ b/internal/store/shares_test.go
@@ -404,3 +404,29 @@ func TestGetUserAllowSharesUnknownUser(t *testing.T) {
 		t.Fatalf("GetUserAllowShares(unknown) = %v, want ErrNotFound", err)
 	}
 }
+
+// TestSharedFlagOnlyWhenAccepted: a task is flagged shared only once a member
+// has accepted — a pending invite alone doesn't badge it as shared.
+func TestSharedFlagOnlyWhenAccepted(t *testing.T) {
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, _ := st.CreateUser(ctx, UserInput{Username: "owner", Role: "user"})
+	member, _ := st.CreateUser(ctx, UserInput{Username: "member", Role: "user"})
+	task, _ := st.CreateTask(ctx, owner.ID, TaskInput{Name: "t"})
+
+	if got, _ := st.GetTask(ctx, owner.ID, task.ID); got.Shared {
+		t.Fatal("a task with no shares should not be flagged shared")
+	}
+	if _, err := st.ShareTask(ctx, owner.ID, task.ID, member.ID); err != nil {
+		t.Fatalf("ShareTask: %v", err)
+	}
+	if got, _ := st.GetTask(ctx, owner.ID, task.ID); got.Shared {
+		t.Fatal("a pending invite should not flag the task as shared")
+	}
+	if err := st.RespondToShare(ctx, member.ID, task.ID, true); err != nil {
+		t.Fatalf("RespondToShare: %v", err)
+	}
+	if got, _ := st.GetTask(ctx, owner.ID, task.ID); !got.Shared {
+		t.Fatal("an accepted share should flag the task as shared")
+	}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -33,7 +33,7 @@ const taskSelect = `
 		t.color_fresh, t.color_overdue, t.freeze_color, t.tags, t.folder, t.archived_at, t.created_at, t.updated_at, t.owner_id,
 		(SELECT MAX(completed_at) FROM completions c WHERE c.task_id = t.id) AS last_completed_at,
 		(SELECT COUNT(*)          FROM completions c WHERE c.task_id = t.id) AS completion_count,
-		EXISTS (SELECT 1 FROM task_shares sh WHERE sh.task_id = t.id) AS shared,
+		EXISTS (SELECT 1 FROM task_shares sh WHERE sh.task_id = t.id AND sh.status = 'accepted') AS shared,
 		(SELECT u.username FROM completions c JOIN users u ON u.id = c.user_id
 		 WHERE c.task_id = t.id ORDER BY c.completed_at DESC, c.id DESC LIMIT 1) AS last_completed_by
 	FROM tasks t`

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -37,6 +37,20 @@ const fix = (text: string, note?: string): Change => ({ text, kind: "fix", note 
 // Newest first. Keep the headline short; put the explanation in the note.
 export const RELEASES: Release[] = [
   {
+    version: "1.12.0",
+    date: "2026-06-15",
+    changes: [
+      feat(
+        "Reminders for shared tasks",
+        "Members of a shared task now get their own due reminders (if they've set a webhook), not just the owner — each reminded independently.",
+      ),
+      fix(
+        "Shared badge",
+        "A task is marked shared only once an invite is accepted; a pending invite alone no longer badges it.",
+      ),
+    ],
+  },
+  {
     version: "1.11.0",
     date: "2026-06-15",
     changes: [


### PR DESCRIPTION
Two follow-ups to shared tasks.

## Reminders for shared members

Previously the reminder loop only notified a task's owner. Now every recipient with a webhook configured is reminded for a shared cadence task:

- `ListReminderCandidates` returns one row per recipient — the owner plus each **accepted** member — joining `reminder_settings` for users who have reminders enabled and a non-empty webhook URL.
- Per-cycle dedup is tracked per `(task_id, user_id)`, so collaborators are reminded independently: marking the owner reminded does not suppress a member, and vice versa.
- `ReminderCandidate` gains a `UserID` (the recipient); `MarkReminded` now takes `(taskID, userID, dueAt)`.
- Migration `0013_reminders_per_user.sql` re-keys `task_reminders` on `(task_id, user_id)`, preserving existing rows attributed to the task owner.

## Shared badge reflects accepted membership

A task is now flagged `shared` only once an invite is **accepted**. A merely pending invite no longer badges the task. The `taskSelect` projection's `EXISTS` check is constrained to `status = 'accepted'`.

## Tests

- `TestReminderCandidatesIncludeSharedMembers` — pending share yields owner only; after accept, owner and member are both candidates with their own webhooks; per-recipient dedup is independent.
- `TestSharedFlagOnlyWhenAccepted` — not shared with no shares, not shared with a pending invite, shared after accept.
- Existing reminder/service tests updated for the per-recipient signature.

Go vet, full Go suite, frontend typecheck, and Vitest all pass.

Version bumped to 1.12.0 (additive migration + new reminder behaviour) with a matching in-app changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_