### PR TITLE
Fix changelog scrollbar drag; remove static version badge

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -176,11 +176,6 @@ export function Sidebar({
             className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
           >
             v{__APP_VERSION__}
-            {release && release.changes.length > 0 && (
-              <span className="rounded bg-secondary px-1 text-[10px] tabular-nums text-secondary-foreground">
-                {release.changes.length}
-              </span>
-            )}
           </button>
           <Button
             variant="outline"

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -37,6 +37,20 @@ const fix = (text: string, note?: string): Change => ({ text, kind: "fix", note 
 // Newest first. Keep the headline short; put the explanation in the note.
 export const RELEASES: Release[] = [
   {
+    version: "1.12.1",
+    date: "2026-06-15",
+    changes: [
+      fix(
+        "Changelog scrolling",
+        "Dragging the scrollbar in the changelog no longer fights an in-progress smooth-scroll and snaps back.",
+      ),
+      fix(
+        "Version label",
+        "Removed the static change-count badge next to the version, which never changed or cleared.",
+      ),
+    ],
+  },
+  {
     version: "1.12.0",
     date: "2026-06-15",
     changes: [

--- a/web/src/lib/smoothScroll.ts
+++ b/web/src/lib/smoothScroll.ts
@@ -21,7 +21,10 @@ const LINE_PX = 16;
 /** Pixel deltas below this are treated as touchpad input and left native. */
 const TOUCHPAD_MAX_PX = 40;
 
-type ScrollState = { target: number };
+// `written` is the scrollTop we last set ourselves, so the next frame can tell
+// our own write apart from an external change (a scrollbar drag, anchor jump,
+// etc.) and bow out instead of fighting it.
+type ScrollState = { target: number; written?: number };
 
 /** Walk up from `from` to the nearest element that can actually scroll further
  *  in the wheel's direction, falling back to the document scroller. */
@@ -59,6 +62,13 @@ export function installSmoothWheel(): () => void {
     const k = 1 - Math.exp(-dt / TAU);
     let active = false;
     states.forEach((s, el) => {
+      // If the position moved by something other than our own last write — the
+      // user grabbed the scrollbar, or the page jumped to an anchor — abandon
+      // the animation so we don't yank it back ("stuck in place" jitter).
+      if (s.written !== undefined && Math.abs(el.scrollTop - s.written) > 2) {
+        states.delete(el);
+        return;
+      }
       const diff = s.target - el.scrollTop;
       if (Math.abs(diff) < 0.5) {
         el.scrollTop = s.target;
@@ -66,6 +76,7 @@ export function installSmoothWheel(): () => void {
         return;
       }
       el.scrollTop += diff * k;
+      s.written = el.scrollTop;
       active = true;
     });
     if (active) raf = requestAnimationFrame(tick);
@@ -82,7 +93,14 @@ export function installSmoothWheel(): () => void {
     if (!el) return;
     e.preventDefault();
 
-    const s = states.get(el) ?? { target: el.scrollTop };
+    // Resume an in-flight animation, but if the element was moved externally
+    // since our last write (e.g. a scrollbar drag), start fresh from where it
+    // actually sits rather than from the stale target.
+    const prev = states.get(el);
+    const s =
+      prev && (prev.written === undefined || Math.abs(el.scrollTop - prev.written) <= 2)
+        ? prev
+        : { target: el.scrollTop };
     const max = el.scrollHeight - el.clientHeight;
     s.target = Math.max(0, Math.min(max, s.target + px));
     states.set(el, s);


### PR DESCRIPTION
Two changelog-UI fixes. Stacked on #14 — base it on `main` once #14 merges.

## Scrollbar drag in the changelog snapped back

While the eased wheel-scroll animation (`lib/smoothScroll.ts`) was in flight, it overwrote `scrollTop` every frame toward its target. Dragging the scrollbar sets `scrollTop` directly, so each drag step was immediately yanked back toward the animation target — the position jittered and appeared stuck ("tries to stay in place"). Reproducible in the demo.

The loop now records the `scrollTop` it writes and, on the next frame, bows out if the element moved by anything other than its own write (a scrollbar drag, an anchor jump). A wheel tick that arrives after such an external move restarts from where the element actually sits instead of a stale target. Normal eased wheel scrolling is unchanged.

## Static change-count badge next to the version

The version label carried a small badge showing the number of entries in the current release. It looked like an unread/notification indicator but only ever showed a fixed count and never cleared. Removed it; the version label still opens the full changelog, and the release date tooltip is unchanged.

## Verification

- Reproduced both in a headless demo build: mid-animation `scrollTop` writes were pulled to 284 before the fix, hold at 50 after; the version button renders `v1.12.1` with no badge span; normal wheel scrolling still eases toward its target.
- `tsc --noEmit` clean; Vitest 17/17 pass (incl. the version/changelog guard).

Version bumped to 1.12.1 (fixes) with a matching in-app changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_