### PR TITLE
Changelog repo + Ko-fi links; full wiki documentation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/ChangelogDialog.tsx
+++ b/web/src/components/ChangelogDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Bug, RefreshCw, Sparkles } from "lucide-react";
+import { Bug, Github, Heart, RefreshCw, Sparkles } from "lucide-react";
 
 import { api } from "@/lib/api";
 import { DEMO } from "@/lib/demo";
@@ -7,6 +7,10 @@ import { useAuth } from "@/components/AuthProvider";
 import { compareVersions, CURRENT_VERSION, formatReleaseDate, type Release, RELEASES } from "@/lib/releases";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+// Project links surfaced in the changelog footer.
+const REPO_URL = "https://github.com/unmaykr-a/taskrr";
+const KOFI_URL = "https://ko-fi.com/unmaykr";
 
 /** ReleaseEntry renders one version: a tag, its date, and the change list with
  *  a sparkles (feature) or bug (fix) icon per line, plus an optional grey note.
@@ -62,6 +66,26 @@ export function ChangelogDialog({
           ))}
         </div>
         {showUpdateCheck && <UpdateCheck />}
+        <div className="flex flex-wrap items-center gap-4 border-t pt-3 text-xs text-muted-foreground">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 transition-colors hover:text-foreground"
+          >
+            <Github className="h-3.5 w-3.5" />
+            GitHub
+          </a>
+          <a
+            href={KOFI_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 transition-colors hover:text-foreground"
+          >
+            <Heart className="h-3.5 w-3.5" />
+            Support on Ko-fi
+          </a>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -37,6 +37,16 @@ const fix = (text: string, note?: string): Change => ({ text, kind: "fix", note 
 // Newest first. Keep the headline short; put the explanation in the note.
 export const RELEASES: Release[] = [
   {
+    version: "1.13.0",
+    date: "2026-06-16",
+    changes: [
+      feat(
+        "Project links",
+        "The changelog now links to the project's GitHub repository and a Ko-fi page for supporting development.",
+      ),
+    ],
+  },
+  {
     version: "1.12.1",
     date: "2026-06-15",
     changes: [

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,121 @@
+# API Reference
+
+Taskrr is a single Go binary that serves a JSON API under `/api` and the embedded
+single-page app for everything else. This page lists the HTTP endpoints. There is
+no separate API token scheme - the API uses the same session cookie as the web UI.
+
+## Conventions
+
+- **Base path:** all endpoints are under `/api`.
+- **Auth:** a session cookie established by sign-in. Endpoints are grouped below
+  by who may call them.
+- **JSON:** request and response bodies are JSON, camelCase (matching
+  `web/src/lib/api.ts`). Timestamps are RFC 3339 in UTC.
+- **Ownership:** task and completion endpoints are scoped to the signed-in user;
+  you can only touch data you own or a task shared with and accepted by you.
+
+## Health and auth (public)
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/health` | Liveness check. |
+| GET | `/api/auth/config` | Public auth/branding config for the login page. |
+| GET | `/api/auth/me` | The current user, or unauthenticated. |
+| POST | `/api/auth/login` | Sign in with username and password. |
+| POST | `/api/auth/claim` | Claim the bootstrap admin by setting its first password. |
+| POST | `/api/auth/logout` | End the current session. |
+| POST | `/api/auth/register` | Self-registration (when enabled). |
+| GET | `/api/auth/oidc/login` | Begin OIDC sign-in. |
+| GET | `/api/auth/oidc/link` | Begin linking OIDC to the signed-in account. |
+| GET | `/api/auth/oidc/callback` | OIDC redirect target. |
+
+## Account self-service (authenticated)
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/me/username` | Change username. |
+| POST | `/api/me/password` | Change password. |
+| DELETE | `/api/me/oidc` | Unlink OIDC identity. |
+| GET | `/api/me/preferences` | Get the per-user preferences blob. |
+| PUT | `/api/me/preferences` | Replace the preferences blob. |
+| GET | `/api/me/reminders` | Get reminder settings. |
+| PUT | `/api/me/reminders` | Update reminder settings. |
+| POST | `/api/me/reminders/test` | Send a test webhook. |
+| GET | `/api/me/shares` | List incoming share requests. |
+| PUT | `/api/me/allow-shares` | Set the share opt-in/out. |
+| POST | `/api/me/wipe` | Delete the user's own tasks and history. |
+| DELETE | `/api/me` | Delete the account. |
+
+## Tasks and completions (authenticated)
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/tasks` | List visible tasks (owned plus accepted shares). |
+| POST | `/api/tasks` | Create a task. |
+| GET | `/api/tasks/{id}` | Get one task. |
+| PATCH | `/api/tasks/{id}` | Update a task (owner only). |
+| POST | `/api/tasks/{id}/archive` | Archive a task. |
+| POST | `/api/tasks/{id}/unarchive` | Restore an archived task. |
+| DELETE | `/api/tasks/{id}` | Delete (member leaves; owner delete transfers or removes). |
+| POST | `/api/tasks/{id}/complete` | Log a completion. |
+| GET | `/api/tasks/{id}/completions` | List a task's completions. |
+| PATCH | `/api/completions/{id}` | Edit a completion (owner or author). |
+| DELETE | `/api/completions/{id}` | Delete a completion (owner or author). |
+| GET | `/api/activity` | Completion activity over a date range. |
+
+## Sharing (authenticated)
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/tasks/{id}/share` | Invite a user to a task (owner). |
+| POST | `/api/tasks/{id}/share/respond` | Accept or decline an invite. |
+| POST | `/api/tasks/{id}/leave` | Leave a shared task. |
+| GET | `/api/tasks/{id}/members` | List a task's members. |
+
+## Version
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/version/latest` | Latest released version (informational). |
+
+## Themes
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/themes/shared` | List admin-published shared themes. |
+
+## Admin (admin only)
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/admin/users` | List users. |
+| POST | `/api/admin/users` | Create a user. |
+| PATCH | `/api/admin/users/{id}` | Update a user (role, username, password). |
+| DELETE | `/api/admin/users/{id}` | Delete a user. |
+| GET | `/api/admin/pending` | List users awaiting approval. |
+| POST | `/api/admin/users/{id}/approve` | Approve a pending user. |
+| POST | `/api/admin/merge` | Merge two accounts. |
+| GET | `/api/admin/sessions` | List active sessions. |
+| DELETE | `/api/admin/sessions/{id}` | Terminate sessions. |
+| GET | `/api/admin/logs` | Tail the in-memory server/access logs. |
+| GET | `/api/admin/settings` | Get instance settings. |
+| PUT | `/api/admin/settings` | Update instance settings. |
+| PUT | `/api/admin/default-theme` | Set the site default theme. |
+| POST | `/api/admin/shared-themes` | Publish a shared theme. |
+| DELETE | `/api/admin/shared-themes/{name}` | Unshare a theme. |
+| POST | `/api/admin/wipe` | Wipe (scope per request body). |
+| POST | `/api/admin/backup` | Create a backup. |
+| GET | `/api/admin/backups` | List backups. |
+| GET | `/api/admin/backups/{name}` | Download a backup. |
+| DELETE | `/api/admin/backups/{name}` | Delete a backup. |
+| POST | `/api/admin/restore/{name}` | Restore from a listed backup. |
+| POST | `/api/admin/restore-upload` | Restore from an uploaded file. |
+
+## SPA fallback
+
+Any path not matched above is served from the embedded single-page app.
+
+> The route list is defined in
+> [`internal/api/server.go`](https://github.com/unmaykr-a/taskrr/blob/main/internal/api/server.go);
+> if you are extending the API, that file and `web/src/lib/api.ts` are the two
+> ends to keep in sync (see [Development and Contributing](Development-and-Contributing)).

--- a/wiki/Admin-Guide.md
+++ b/wiki/Admin-Guide.md
@@ -1,0 +1,90 @@
+# Admin Guide
+
+Admins get an in-app admin area covering users, instance settings, sessions,
+logs, backups, and themes. This page is an overview of what lives there; several
+topics have their own dedicated pages.
+
+## Users
+
+- List, create, edit, and delete users; change roles (admin / user).
+- The bootstrap admin is protected - it cannot be edited or deleted by other
+  admins.
+- **Merge** two accounts into one (optionally moving data), useful when migrating
+  someone onto SSO.
+- In [lite mode](Users-and-Authentication) the Users section is hidden.
+
+## Registration and approvals
+
+Self-registration is off by default. The relevant settings:
+
+- **Local registration** (`reg_local`) - allow username/password self sign-up.
+- **OIDC auto-provision** (`reg_oidc`) - create a user on first OIDC login.
+- **Approval required** (`reg_approval`) - new local sign-ups wait for admin
+  approval. Pending users appear in a queue to **approve** or **deny**.
+
+See [Users and Authentication](Users-and-Authentication).
+
+## Single sign-on (OIDC)
+
+Configure the issuer, client id/secret, redirect URL, the admin group, username
+linking, and OIDC-only mode. Full details and provider notes are in
+[OIDC Single Sign-On](OIDC-Single-Sign-On).
+
+## Shared tasks
+
+The **Task sharing** gate (`tasks_shareable`) turns the whole shared-tasks
+feature on or off for the instance. While off, the share UI is hidden and the
+server refuses new shares. See [Shared Tasks](Shared-Tasks).
+
+## Themes (instance-wide)
+
+- **Set as site default** - publish a theme as the instance default, shown even
+  on the signed-out login page (`default_theme`).
+- **Use the default for everyone** (`default_theme_enforce`) - accounts that have
+  not customised their own theme follow the site default and pick up changes. The
+  moment a user changes their theme, theirs wins - it is a default, not a lock.
+- **Allow sharing themes** (`themes_shareable`) - lets admins publish saved
+  themes to all users; **Let everyone share** (`themes_share_users`) additionally
+  lets non-admins publish.
+
+See [Theming and Branding](Theming-and-Branding).
+
+## Branding
+
+Customise the instance identity (admin settings): name, browser tab title,
+tagline, an uploaded icon, and toggles to hide the icon or name/tagline on the
+login card. Branding is applied even when signed out. Details in
+[Theming and Branding](Theming-and-Branding).
+
+## Sessions
+
+View all active sessions and **terminate** them - for a single user or in bulk.
+Useful after a password change or to revoke a lost device.
+
+## Live logs
+
+A live tail of the server and access logs is available in the admin area, and can
+be **popped out** as a floating window so you can watch it while changing
+settings. Webhook URLs are stripped from reminder failure messages here.
+
+## Backups and restore
+
+Create, download, delete, and one-click restore database backups, or restore from
+an uploaded file. A safety snapshot is taken before each restore by default. This
+has its own page: [Backups and Restore](Backups-and-Restore).
+
+## Wipe everything
+
+A destructive admin action that resets the instance to a fresh state while
+keeping your own admin login: it removes all other users and their data, all
+tasks and history (including the admin's), all settings (OIDC config,
+registration toggles, the site default theme), all preferences, and all reminder
+state. The confirmation dialog spells out the scope. Use with care - take a
+backup first.
+
+## Check for updates
+
+The changelog (opened from the version label) includes an admin-only "Check for
+updates" that reports whether a newer version exists, read from
+`TASKRR_UPDATE_CHECK_URL`. It is informational only - Taskrr never updates itself.
+To update, pull the new image (see [Installation](Installation)).

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,89 @@
+# Architecture
+
+Taskrr is deliberately small: one Go binary that embeds the web UI and a pure-Go
+SQLite database, with no external services. This page explains how the pieces fit
+together.
+
+## Big picture
+
+- **Backend (Go).** A single statically linked binary (`CGO_ENABLED=0`) using
+  pure-Go SQLite (`modernc.org/sqlite`). Routing is the standard library
+  (`net/http` with Go 1.22+ method patterns) - no web framework. Handlers depend
+  on small store interfaces, which are the seam for swapping the data layer.
+- **Frontend (React + TypeScript + Vite).** Tailwind CSS and shadcn/ui
+  components, with TanStack Query for data fetching. It is built and embedded into
+  the binary with `go:embed`, so there is nothing to serve separately.
+- **Storage.** A single SQLite file under `./data`. Completions are an
+  append-only log; a task's routine is a nullable interval column.
+
+## Layout
+
+```
+cmd/taskrr/        entrypoint
+internal/config/   environment configuration
+internal/store/    SQLite data layer + SQL migrations
+internal/api/      HTTP handlers, store interfaces, SPA serving
+internal/auth/     password hashing + session tokens + secret cipher
+internal/reminder/ the webhook reminder loop
+internal/web/      go:embed of the built frontend
+web/               the React/TypeScript/Vite frontend (source)
+```
+
+## Request flow
+
+1. A request hits the `net/http` mux defined in `internal/api/server.go`.
+2. Middleware adds security headers, access logging, and resolves the session
+   cookie to a user.
+3. The handler validates input and calls a store method through one of the
+   interfaces (`TaskStore`, `AuthStore`, `ShareStore`). Every task/completion
+   method is scoped by the acting user's id, so a request can only reach its own
+   data (or a task shared with and accepted by it).
+4. Anything not matched by an `/api` route falls through to the embedded SPA.
+
+## The store interfaces
+
+`internal/api/server.go` defines the data surface the HTTP layer needs as Go
+interfaces. The concrete `*store.Store` (SQLite) satisfies them, and tests supply
+fakes. New data-layer work goes behind these interfaces, which keeps transport
+concerns decoupled from the database.
+
+## Data model notes
+
+- **Tasks** carry a name, description, optional routine (`interval_seconds`),
+  colours, tags, and a folder, owned by a user.
+- **Completions** are append-only - each row records when, an optional note, and
+  who logged it. "Time since" and staleness derive from the latest completion.
+- **Sharing** keeps a task a single row and attaches members via a
+  `task_shares` table (pending/accepted), rather than duplicating the task.
+- **Reminders** are tracked per recipient so collaborators are nudged
+  independently.
+
+## Migrations
+
+Schema changes are SQL files under `internal/store/migrations/`, named
+`NNNN_name.sql`. They run in filename order on start and are recorded in a
+`schema_migrations` table so each runs exactly once. Applied migrations are never
+edited; new changes are new files.
+
+## Conventions
+
+- Timestamps are RFC 3339 UTC text in the database; the Go layer owns the format.
+  JSON is camelCase to match the frontend client.
+- Tunable UI policy (staleness colours/thresholds, filter views) lives in
+  `web/src/lib/` and is unit-tested, separate from components.
+- Versioning is semantic; the single source of truth is `web/package.json`,
+  surfaced in the app as the version label and the in-app changelog.
+
+## Security posture (summary)
+
+- Strict security headers and a tight Content-Security-Policy on every response;
+  HSTS over HTTPS.
+- Per-username and per-IP sign-in rate limiting.
+- Session tokens stored hashed.
+- The reminder webhook client blocks SSRF to internal addresses and does not
+  follow redirects (see [Reminders](Reminders)).
+- The OIDC client secret can be encrypted at rest with `TASKRR_SECRET_KEY`.
+
+For a deeper dive, read the source - it is compact and commented. The
+[Development and Contributing](Development-and-Contributing) page covers building
+and testing.

--- a/wiki/Backups-and-Restore.md
+++ b/wiki/Backups-and-Restore.md
@@ -1,0 +1,56 @@
+# Backups and Restore
+
+Taskrr stores everything in a single SQLite file under `./data`. That makes
+backups simple, and the admin area adds in-app backup and restore on top.
+
+## The simplest backup: copy the folder
+
+Because all state lives in `./data`, copying that folder (while the container is
+stopped, or using the in-app backup which is consistent) is a complete backup.
+Moving the instance to another host is moving that folder.
+
+## In-app backups (admin)
+
+From the admin area you can:
+
+- **Create a backup** - a snapshot of the database, saved under the backups
+  folder in your data directory.
+- **List** existing backups.
+- **Download** a backup file to keep off-box.
+- **Delete** backups you no longer need.
+
+## Restoring
+
+You can restore in two ways:
+
+- **From a listed backup** - one-click restore of a snapshot Taskrr is holding.
+- **From an uploaded file** - restore a backup you downloaded earlier (for
+  example onto a fresh instance).
+
+A restore is **staged and then applied on restart**: Taskrr swaps the database in
+and restarts the process. Under Docker, the container's restart policy brings it
+straight back up. While a restore is staged, the instance is briefly busy.
+
+### The safety snapshot
+
+By default (`TASKRR_SAFETY_BACKUP=true`) Taskrr takes an automatic backup of the
+current database **right before** applying a restore, so a mistaken restore can be
+undone. If you would rather not accumulate a safety copy on every restore, set
+`TASKRR_SAFETY_BACKUP=false` (see [Configuration](Configuration)). The restart log
+notes when the safety snapshot was skipped.
+
+## Secrets in backups
+
+If you have **not** set `TASKRR_SECRET_KEY`, the OIDC client secret is stored in
+plaintext and therefore included in downloadable backups. Set `TASKRR_SECRET_KEY`
+to encrypt it at rest so it never appears in a backup. Note that a backup
+encrypted with one key cannot be read after the key changes - keep the key stable
+and stored safely. See [OIDC Single Sign-On](OIDC-Single-Sign-On).
+
+## A good routine
+
+- Keep `TASKRR_SAFETY_BACKUP=true` so restores are reversible.
+- Periodically **download** a backup off the host (or back up the `./data`
+  folder externally) so a disk failure does not take your only copy with it.
+- Before a risky change (a big import, or the admin **Wipe everything** action),
+  take a fresh backup first.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,100 @@
+# Configuration
+
+Everything is configured through environment variables. Every value has a
+sensible default, so an unconfigured instance still starts. The canonical,
+commented list is
+[`.env.example`](https://github.com/unmaykr-a/taskrr/blob/main/.env.example);
+this page explains each variable in more depth.
+
+When using Docker Compose, put these in a `.env` file next to the compose file.
+
+> Compose treats a single `$` as variable interpolation. Any value containing a
+> `$` (notably a hashed password or an OIDC secret) must have each `$` doubled to
+> `$$` in the `.env` file.
+
+## Core
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TASKRR_ADDR` | `:8787` | Listen address. Use `127.0.0.1:8787` to bind to loopback only (for example, behind a proxy on the same host). |
+| `TASKRR_DB_PATH` | `./data/taskrr.db` | Path to the SQLite file. The parent directory is created if missing. |
+| `TASKRR_SESSION_TTL` | `720h` | How long a sign-in lasts (a Go duration such as `720h`, `30m`). Sessions slide - they extend while in use. |
+| `TASKRR_LITE` | `false` | Single-person mode. Disables self-registration and the ability to create extra accounts. See [Users and Authentication](Users-and-Authentication). |
+| `TASKRR_REMINDER_INTERVAL` | `1m` | How often the reminder loop wakes to check for due tasks. See [Reminders](Reminders). |
+
+## The bootstrap admin
+
+On first start, a single admin account is created so you can sign in.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TASKRR_ADMIN_USERNAME` | `admin` | Username of the bootstrap admin created on first start. |
+| `TASKRR_ADMIN_PASSWORD` | - | Its password. Leave unset to choose one in the browser on the first sign-in. |
+| `TASKRR_ADMIN_PASSWORD_HASH` | - | A pre-computed hash, used instead of the plaintext password (the hash wins if both are set). |
+
+The bootstrap admin is **protected**: other admins cannot edit or delete it, and
+it keeps password sign-in even in OIDC-only mode, so a provider outage can never
+lock you out (the break-glass path).
+
+### Generating a password hash
+
+You can avoid putting a plaintext password in your `.env` by precomputing a hash.
+The built-in helper prints one (already `$$`-escaped for a Compose `.env`):
+
+```bash
+docker compose run --rm taskrr -hash-password 'your-password' | sed 's/[$]/$$/g'
+```
+
+The format is `pbkdf2-sha256$<iterations>$<salt>$<key>`.
+
+## Security and proxying
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TASKRR_COOKIE_SECURE` | `false` | Set `true` when served over HTTPS so the session cookie is marked Secure. |
+| `TASKRR_TRUST_PROXY_HEADERS` | `true` | Read the client IP from reverse-proxy headers (`CF-Connecting-IP`, `X-Forwarded-For`) for rate limiting and logs. Set `false` if Taskrr is exposed directly, so those headers cannot be spoofed to dodge the per-IP rate limiter. |
+| `TASKRR_SECRET_KEY` | - | Encrypts the OIDC client secret at rest, so it is never stored - or included in downloadable backups - in plaintext. Any string; keep it secret and stable. Changing it makes an existing stored secret unreadable, so you would re-enter it. |
+
+See [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS) for how these fit
+together. In short: HSTS is sent automatically over HTTPS, either directly
+(`TASKRR_COOKIE_SECURE=true`) or via a trusted proxy reporting
+`X-Forwarded-Proto: https`.
+
+## Backups and updates
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TASKRR_SAFETY_BACKUP` | `true` | Take an automatic snapshot of the database right before a restore, so a mistaken restore is undoable. Set `false` to stop the backups folder collecting a safety snapshot on every restore. |
+| `TASKRR_UPDATE_CHECK_URL` | project `package.json` | The source the changelog's admin-only "Check for updates" reads to report the latest released version. It is informational only - it never updates the app. Set empty to disable the check entirely. |
+
+## OIDC single sign-on
+
+These can also be set later in the admin UI; environment values seed the initial
+configuration. A secret containing `$` needs each one doubled to `$$`.
+
+| Variable | What it does |
+| --- | --- |
+| `TASKRR_OIDC_ISSUER` | The issuer URL, for example `https://auth.example.com/application/o/taskrr/`. |
+| `TASKRR_OIDC_CLIENT_ID` | The OAuth client id. |
+| `TASKRR_OIDC_CLIENT_SECRET` | The OAuth client secret (encrypted at rest when `TASKRR_SECRET_KEY` is set). |
+| `TASKRR_OIDC_REDIRECT_URL` | The callback URL, your public origin plus `/api/auth/oidc/callback`. |
+
+Full details, including group-to-admin-role mapping and OIDC-only mode, are in
+[OIDC Single Sign-On](OIDC-Single-Sign-On).
+
+## Container user (Docker)
+
+The compose file honours two extra variables for file ownership of the `./data`
+bind mount:
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TASKRR_UID` | `1000` | uid the container process runs as. |
+| `TASKRR_GID` | `1000` | gid the container process runs as. |
+
+## Settings stored in the database
+
+Beyond environment variables, many instance options live in the database and are
+edited from the admin UI rather than the environment - registration controls,
+the shared-tasks gate, theme sharing, branding, and the OIDC settings above.
+These are documented in the [Admin Guide](Admin-Guide).

--- a/wiki/Development-and-Contributing.md
+++ b/wiki/Development-and-Contributing.md
@@ -1,0 +1,97 @@
+# Development and Contributing
+
+This page covers building Taskrr from source, the development workflow, and the
+conventions to follow when contributing.
+
+## Prerequisites
+
+- **Go 1.25+**
+- **Node 22+**
+
+## Build
+
+```bash
+git clone https://github.com/unmaykr-a/taskrr.git
+cd taskrr
+make build      # builds the frontend, then the Go binary -> bin/taskrr
+./bin/taskrr    # serves on :8787, data in ./data
+```
+
+## Make targets
+
+| Target | What it does |
+| --- | --- |
+| `make build` | Build the frontend and backend into `bin/taskrr`. |
+| `make frontend` | Install deps and build the frontend into the embed dir. |
+| `make backend` | Build the Go binary (embeds whatever is in `internal/web/dist`). |
+| `make run` | Build everything and run on `:8787`. |
+| `make dev-backend` | Run the backend with live logs (no frontend build), `:8787`. |
+| `make dev-frontend` | Run the Vite dev server (proxies `/api` to `:8787`). |
+| `make test` | Run all tests (Go + frontend). |
+| `make test-go` | Run the Go tests. |
+| `make test-web` | Run the frontend unit tests. |
+| `make vet` | `go vet` plus the frontend TypeScript typecheck. |
+| `make install-hooks` | Enable the pre-commit hook that blocks commits on failing checks. |
+| `make tidy` | Tidy Go modules. |
+| `make docker` | Build the Docker image for the local architecture. |
+| `make clean` | Remove build artifacts. |
+
+## Development loop
+
+Run two terminals:
+
+```bash
+make dev-backend     # API on :8787
+make dev-frontend    # Vite on :5173, proxying /api to :8787
+```
+
+The Vite dev server gives instant frontend reloads. The Go backend serves the API
+directly. Note that `make dev-backend` (or `go run`) serves whatever is currently
+in `internal/web/dist`; to see frontend changes in the **embedded** binary you
+must rebuild it (`make frontend` or `make build`).
+
+## Project conventions
+
+- **Timestamps** are RFC 3339 UTC text in the database; the Go layer owns the
+  format. JSON is camelCase to match `web/src/lib/api.ts`.
+- **Migrations:** add `internal/store/migrations/NNNN_name.sql`. They run in
+  filename order and are tracked in `schema_migrations`. Never edit an applied
+  migration.
+- **Adding an endpoint:** add the route in `internal/api/server.go` (and to the
+  relevant store interface if it needs the data layer), the handler in the API
+  package, the store method in `internal/store/`, and the client method and type
+  in `web/src/lib/api.ts`.
+- **Tunable UI policy** (staleness colours/thresholds, filter views) lives in
+  `web/src/lib/` and is unit-tested - change it there, not in components.
+- **UI primitives** live in `web/src/components/ui/`; feature components sit above
+  them.
+- **No emojis** anywhere - code, comments, UI strings, docs, commit messages, or
+  shell output. Use plain text or a lucide icon.
+- **Versioning** is semantic, with a single source of truth in
+  `web/package.json`. Bump it in the same change: PATCH for fixes, MINOR for
+  features, MAJOR for breaking changes. Add a matching entry to the in-app
+  changelog (`web/src/lib/releases.ts`); a test enforces that the top entry
+  matches the current version.
+
+## Testing
+
+- `make test` runs the Go suite and the frontend Vitest suite.
+- `make vet` runs `go vet` and the TypeScript typecheck.
+- `make install-hooks` wires these into a pre-commit gate.
+
+Run the full set before opening a pull request.
+
+## Continuous integration
+
+CI runs Go vet/build/test, the frontend typecheck/test/build, and a multi-arch
+(`amd64`, `arm64`) Docker build. Keep changes green.
+
+## Pull requests
+
+Open a pull request against `main`, keep it focused, and make sure CI passes.
+Update the in-app changelog and bump the version when your change is user-facing.
+
+## Architecture
+
+See [Architecture](Architecture) for how the backend, frontend, storage, and
+store interfaces fit together.

--- a/wiki/FAQ-and-Troubleshooting.md
+++ b/wiki/FAQ-and-Troubleshooting.md
@@ -1,0 +1,114 @@
+# FAQ and Troubleshooting
+
+## General
+
+### What is Taskrr for?
+
+Tracking recurring things by **how long it's been** since you last did them, not
+by deadline - chores, maintenance, anything cyclical. See
+[Tasks and Routines](Tasks-and-Routines).
+
+### How much does it need to run?
+
+Roughly 12 MB of RAM at idle and under half a percent of one CPU core. It runs on
+a Raspberry Pi (`arm64`) or any small box.
+
+### Where is my data?
+
+In a single SQLite file under `./data` (`TASKRR_DB_PATH`). Backing up or moving
+the instance is copying that folder. See [Backups and Restore](Backups-and-Restore).
+
+## Sign-in and accounts
+
+### I forgot the admin password.
+
+The bootstrap admin keeps password sign-in even in OIDC-only mode. If you set
+`TASKRR_ADMIN_PASSWORD` or `TASKRR_ADMIN_PASSWORD_HASH` in the environment, that
+value applies. You can also generate a fresh hash and set it (see
+[Configuration](Configuration)).
+
+### Sign-in keeps getting rejected / rate limited.
+
+Sign-in is rate limited per username and per source IP (to blunt brute force and
+password-spraying). Wait a few minutes and try again. Behind a proxy, make sure
+`TASKRR_TRUST_PROXY_HEADERS=true` so the limiter sees the real client IP rather
+than the proxy's.
+
+### My session keeps dropping / cookie not sticking.
+
+Over HTTPS, set `TASKRR_COOKIE_SECURE=true` so the cookie is issued correctly as
+Secure. See [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS).
+
+## OIDC
+
+### OIDC login fails at the callback.
+
+Check that the redirect URL matches exactly on both sides - it should be your
+public origin plus `/api/auth/oidc/callback`. Confirm the issuer URL, client id,
+and secret. See [OIDC Single Sign-On](OIDC-Single-Sign-On).
+
+### A user signed in with OIDC but got a brand-new account.
+
+By default OIDC identities are separate accounts. Turn on **Link by username**
+(`oidc_link_username`) to link a first OIDC sign-in to a matching local account,
+or use the admin **merge** action to combine two accounts.
+
+### OIDC users are not being created.
+
+Turn on **OIDC auto-provision** (`reg_oidc`) so a user is created on first
+successful OIDC login.
+
+### An admin lost their admin role after signing in with OIDC.
+
+Group membership syncs the role for SSO-managed accounts. An admin role granted
+locally (the account has a password) is never stripped; only accounts whose role
+is governed by OIDC are demoted when they leave the admin group.
+
+## Reminders
+
+### The test webhook works but reminders never fire.
+
+Only tasks with a routine and at least one completion can be due. Confirm the
+task has an interval and has been logged at least once, and that the recipient has
+reminders enabled with a webhook. The loop checks every
+`TASKRR_REMINDER_INTERVAL` (default `1m`).
+
+### My webhook to a local service is refused.
+
+The client blocks loopback, link-local, multicast, and cloud-metadata addresses,
+and does not follow redirects. Private/LAN addresses (`192.168.x.x`, `10.x.x.x`)
+are allowed - point at the LAN IP of your ntfy / Home Assistant rather than
+`localhost`. See the security section of [Reminders](Reminders).
+
+## Files and Docker
+
+### The files in ./data are owned by the wrong user.
+
+The container runs as uid/gid `1000` by default. Set `TASKRR_UID` / `TASKRR_GID`
+to match your user. See [Installation](Installation).
+
+### How do I update?
+
+`docker compose pull && docker compose up -d`. Migrations run automatically. There
+is no in-app auto-update; the changelog's "Check for updates" is informational
+only.
+
+## Sharing
+
+### I do not see any share controls.
+
+Sharing is an admin-gated feature (`tasks_shareable`). An admin must enable
+**Task sharing** first. It is also unavailable in the in-browser demo. See
+[Shared Tasks](Shared-Tasks).
+
+## Demo
+
+### Can I try it without installing?
+
+Yes - the [live demo](https://unmaykr-a.github.io/taskrr/) runs entirely in your
+browser against a mock API. The admin area, SSO, backups, and reminder delivery
+need a real server, so they are not in the demo.
+
+## Still stuck?
+
+Open an issue on [GitHub](https://github.com/unmaykr-a/taskrr/issues).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,66 @@
+# Taskrr
+
+**A self-hosted tracker for when you last did things.**
+
+Some things aren't really to-dos. Watering the plants, cleaning the dehumidifier
+filter, backing up the NAS, descaling the kettle - what matters isn't a deadline,
+it's *how long it's been*. Taskrr is built around exactly that: create a task
+once, tap **Quick log** each time you do it, and the card counts up from there.
+Give a task a routine ("every 2 weeks") and it shades from green to red as the
+next one comes due.
+
+The whole app is one small binary with the web UI and SQLite database baked in.
+It idles at roughly 12 MB of memory and under half a percent of one CPU core, so
+it runs happily on a Raspberry Pi or any small box you already have.
+
+## Try it first
+
+The [live demo](https://unmaykr-a.github.io/taskrr/) is the real UI with no
+backend - it runs against an in-browser mock of the API, seeded with sample data
+and saved to your browser's local storage. There's no account and no server.
+The admin area, single sign-on, backups, and reminder delivery need a real
+server, so they aren't part of the demo.
+
+## Where to start
+
+- New here? [Installation](Installation) gets you running with Docker in a
+  couple of minutes, then sign in as `admin`.
+- Tuning the instance? [Configuration](Configuration) documents every
+  environment variable, and [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS)
+  covers the public-facing setup.
+- Day-to-day use is in [Tasks and Routines](Tasks-and-Routines),
+  [Shared Tasks](Shared-Tasks), and [Reminders](Reminders).
+- Running it for other people? See the [Admin Guide](Admin-Guide),
+  [Users and Authentication](Users-and-Authentication), and
+  [Backups and Restore](Backups-and-Restore).
+
+## Feature overview
+
+- One-tap logging, or pick a time and add a note. History is editable - every
+  logged completion can be changed or undone later.
+- Routines with due dates: cards shade continuously from fresh to overdue, with
+  a progress bar and "due in 3d" on each card. Colours are customisable per task
+  and globally.
+- A month calendar of what you did and what's coming up, plus an activity chart
+  of your last 30 days.
+- Filters with live counts (all, due soon, overdue, never done, archived) and
+  bulk actions.
+- Tags with search and a tag filter, folder grouping, and sorting by name or
+  last-done.
+- Multiple users with per-user data, local password login, and optional OIDC
+  single sign-on with group-to-admin-role mapping. A lite mode turns the
+  multi-user surface off for solo use.
+- Share a task with another user so you both see and log it.
+- An admin area: user management, registration controls with an approval queue,
+  active sessions, live server logs, backups with one-click restore, and
+  instance settings.
+- Reminders via webhook when a task is due - ntfy, Gotify, Apprise, Home
+  Assistant, a Discord webhook, or anything that accepts JSON.
+- A themeable interface: colour customiser with palette generation, light and
+  dark modes, animated backgrounds, frosted glass, floating windows, and
+  per-animation toggles. Works well on a phone.
+
+## License
+
+Taskrr is released under the [MIT License](https://github.com/unmaykr-a/taskrr/blob/main/LICENSE).
+If it is useful to you, you can [support development on Ko-fi](https://ko-fi.com/unmaykr).

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,89 @@
+# Installation
+
+Taskrr ships as a single container image with the web UI and a pure-Go SQLite
+database built in. The recommended way to run it is Docker Compose.
+
+## Requirements
+
+- Docker with the Compose plugin (`docker compose`).
+- A directory for the database (`./data`), bind-mounted into the container.
+- Roughly 12 MB of RAM at idle. It runs on `amd64` and `arm64` (Raspberry Pi).
+
+## Quick start (Docker Compose)
+
+No cloning and no building - just the compose file:
+
+```bash
+mkdir taskrr && cd taskrr
+curl -LO https://raw.githubusercontent.com/unmaykr-a/taskrr/main/docker-compose.yml
+mkdir data
+docker compose up -d
+```
+
+Open <http://localhost:8787> and sign in as `admin`. On the first sign-in you are
+asked to set the admin password (unless you preset one - see
+[Configuration](Configuration)).
+
+Your data lives in the plain `./data` folder next to the compose file. Backing up
+or moving the instance is just copying that folder.
+
+### File ownership
+
+The container writes as uid/gid `1000` by default (a typical single-user Linux
+box). If `id -u` reports something else, set `TASKRR_UID` / `TASKRR_GID` in your
+environment (or `.env`) so the files in `./data` are owned by you.
+
+## Configuration file
+
+To preset the admin password or change anything else up front, drop a `.env`
+file next to the compose file. The repository's
+[`.env.example`](https://github.com/unmaykr-a/taskrr/blob/main/.env.example)
+documents every option with working examples, and
+[Configuration](Configuration) explains each one.
+
+## The container image
+
+Images are published to GitHub Container Registry:
+
+- `ghcr.io/unmaykr-a/taskrr:latest` - the latest release.
+- `ghcr.io/unmaykr-a/taskrr:<version>` - a specific version (for example
+  `:1.13.0`), so you can pin or roll back. Versioned tags exist from 1.5.0
+  onward.
+
+The image is multi-arch (`amd64`, `arm64`); Docker pulls the right one for your
+host automatically.
+
+## Running the binary directly
+
+If you prefer not to use Docker, build from source (Go 1.25+ and Node 22+):
+
+```bash
+git clone https://github.com/unmaykr-a/taskrr.git
+cd taskrr
+make build      # builds the frontend and backend -> bin/taskrr
+./bin/taskrr    # serves on :8787, data in ./data
+```
+
+See [Development and Contributing](Development-and-Contributing) for the full
+build and test workflow.
+
+## Updating
+
+With Compose:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Schema migrations run automatically on start, in order, and are tracked so they
+only ever run once. There is no in-app auto-update; the admin changelog has an
+optional, informational "Check for updates" that only reports whether a newer
+version exists (see [Configuration](Configuration) and the
+[Admin Guide](Admin-Guide)).
+
+## Next steps
+
+- [Configuration](Configuration) - every environment variable.
+- [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS) - exposing it safely.
+- [Backups and Restore](Backups-and-Restore) - protecting your data.

--- a/wiki/OIDC-Single-Sign-On.md
+++ b/wiki/OIDC-Single-Sign-On.md
@@ -1,0 +1,92 @@
+# OIDC Single Sign-On
+
+Taskrr supports OpenID Connect for single sign-on, tested with **Authentik** and
+**Pocket ID** (any standards-compliant provider should work). You can configure
+it through environment variables, the admin UI, or both - environment values seed
+the initial settings and the admin UI can change them later.
+
+## Register the application with your provider
+
+Create an OAuth/OIDC application in your identity provider and note:
+
+- **Issuer URL** - for example `https://auth.example.com/application/o/taskrr/`.
+- **Client ID** and **Client secret**.
+- **Redirect URL** - your public origin plus `/api/auth/oidc/callback`, for
+  example `https://taskrr.example.com/api/auth/oidc/callback`. It must match
+  exactly on both sides.
+
+Taskrr requests standard scopes and reads these claims: `sub` (the stable
+subject), `preferred_username`, `email`, and `groups`.
+
+## Configure Taskrr
+
+Set these via environment (see [Configuration](Configuration)) or in the admin
+settings:
+
+| Setting | Env | Meaning |
+| --- | --- | --- |
+| Issuer | `TASKRR_OIDC_ISSUER` | The provider's issuer URL. |
+| Client ID | `TASKRR_OIDC_CLIENT_ID` | The application's client id. |
+| Client secret | `TASKRR_OIDC_CLIENT_SECRET` | The application's client secret. |
+| Redirect URL | `TASKRR_OIDC_REDIRECT_URL` | The callback URL above. |
+| Admin group | (admin UI: `oidc_admin_group`) | Group whose members become admins. |
+| Link by username | (admin UI: `oidc_link_username`) | Link a first OIDC sign-in to an existing local account with the same username. |
+| OIDC-only | (admin UI: `oidc_only`) | Hide local login and accept only SSO. |
+
+Encrypt the client secret at rest by setting `TASKRR_SECRET_KEY`; otherwise it is
+stored in plaintext (and would appear in backups). Changing the key makes an
+existing stored secret unreadable, so re-enter it if you rotate the key.
+
+## Account provisioning
+
+- **First sign-in.** When **OIDC auto-provision** (`reg_oidc`) is on, a new user
+  is created automatically on their first successful OIDC login. The username is
+  taken from `preferred_username`, falling back to `email`, then the subject.
+- **Linking to an existing account.** By default a new OIDC identity is its own
+  account. Turn on **Link by username** (`oidc_link_username`) to link a first
+  OIDC sign-in to an existing local account whose username matches. Users can
+  also link/unlink SSO themselves from their account settings.
+- **Stable identity.** Accounts are matched by the OIDC `subject`, so a username
+  change at the provider does not detach the account.
+
+## Group-to-admin-role mapping
+
+Set an **admin group**. On each OIDC sign-in, group membership is synced to the
+role:
+
+- A user in the admin group is promoted to **admin**.
+- If they are no longer in the group, they are demoted **only when their role is
+  governed by OIDC** - that is, an account with no local password. An admin role
+  granted locally (the account has a password) is never silently stripped, and
+  the protected bootstrap admin is always left alone.
+
+In other words: the group can grant and revoke admin for SSO-managed accounts,
+but cannot remove a role you assigned by hand.
+
+## OIDC-only mode
+
+Turn on **OIDC-only** to make SSO the sole sign-in method:
+
+- The login page hides the username/password form entirely and shows a single
+  sign-on button.
+- The server refuses local login, account claim, and registration, with the same
+  message for known and unknown accounts (no user enumeration).
+- The **protected bootstrap admin keeps password sign-in** as a break-glass path,
+  so a provider outage cannot lock the instance out.
+- The toggle is inert while OIDC is unconfigured, so enabling it prematurely
+  cannot strand anyone.
+
+## Endpoints
+
+For reference, the OIDC flow uses:
+
+- `GET /api/auth/oidc/login` - begin sign-in.
+- `GET /api/auth/oidc/link` - begin linking from a signed-in account.
+- `GET /api/auth/oidc/callback` - the provider redirect target.
+
+See the [API Reference](API-Reference).
+
+## Migrating local users to SSO
+
+If a person has both a local and an OIDC account, an admin can **merge** them
+(moving data to the target). See [Users and Authentication](Users-and-Authentication).

--- a/wiki/Reminders.md
+++ b/wiki/Reminders.md
@@ -1,0 +1,83 @@
+# Reminders
+
+Taskrr can send an outbound webhook when a task with a routine becomes due, so
+you get a nudge in whatever notification system you already use. Reminders are
+configured per user.
+
+## What you can point it at
+
+The payload carries several common keys (`title`, `message`, `content`, plus
+`task`, `taskId`, `dueAt`), so it works as-is with:
+
+- [ntfy](https://ntfy.sh)
+- Gotify
+- Apprise
+- Home Assistant webhooks
+- A Discord webhook (the `content` key)
+- Anything that accepts a JSON POST
+
+## Setting it up
+
+In your account's **Reminders** settings:
+
+1. **Enable** reminders.
+2. Enter your **webhook URL**.
+3. Optionally set a **lead time** - fire the reminder this long *before* the due
+   time (0 means at the due time / once overdue).
+4. Use **Send test** to post a sample payload and confirm delivery.
+
+A reminder fires once per due cycle. A cycle advances each time the task is
+completed, so completing a task resets it for the next interval.
+
+## How the loop works
+
+A single background loop wakes on an interval (`TASKRR_REMINDER_INTERVAL`,
+default `1m`) and, for each due task whose recipient has reminders enabled, POSTs
+the payload exactly once for that cycle. A failed delivery is logged and retried
+on the next tick; a successful one is recorded so it does not fire again for the
+same cycle.
+
+Only tasks that have a routine and at least one completion can be due, so a task
+with no cadence, or one never logged, never triggers a reminder.
+
+## Shared tasks
+
+For a [shared task](Shared-Tasks), every recipient with a webhook configured -
+the owner and each accepted member - is reminded independently. Marking one
+recipient reminded does not suppress another; each is tracked per recipient.
+
+## Example payload
+
+```json
+{
+  "title": "Taskrr reminder",
+  "message": "\"Water plants\" is due (overdue by 2h).",
+  "content": "\"Water plants\" is due (overdue by 2h).",
+  "task": "Water plants",
+  "taskId": 12,
+  "dueAt": "2026-06-16T09:00:00Z"
+}
+```
+
+## Security (SSRF protection)
+
+Because the webhook URL is user-supplied, deliveries are constrained:
+
+- The scheme must be `http` or `https`.
+- At dial time, on the **resolved IP**, Taskrr refuses to connect to loopback,
+  link-local / cloud-metadata (such as `169.254.169.254`), multicast, and the
+  unspecified address. A hostname that resolves or redirects to a blocked address
+  is still refused.
+- Redirects are not followed, so a public URL cannot bounce to an internal one.
+
+Private / LAN ranges (RFC 1918, such as `192.168.x.x`, `10.x.x.x`) are
+intentionally **allowed**, because reaching a local ntfy or Home Assistant is the
+point, and accounts are admin-created. If you run Taskrr exposed directly, keep
+this in mind.
+
+Webhook URLs are returned only to their owner by the API, and are stripped from
+delivery-failure messages in the admin log.
+
+## Not in the demo
+
+Reminder delivery needs a real server, so it is not part of the in-browser demo.

--- a/wiki/Reverse-Proxy-and-HTTPS.md
+++ b/wiki/Reverse-Proxy-and-HTTPS.md
@@ -1,0 +1,96 @@
+# Reverse Proxy and HTTPS
+
+For anything beyond your own LAN, run Taskrr behind a TLS-terminating reverse
+proxy. Taskrr itself speaks plain HTTP; the proxy handles certificates and
+forwards requests to it.
+
+## The two settings that matter
+
+- **`TASKRR_COOKIE_SECURE=true`** - set this whenever users reach Taskrr over
+  HTTPS, so the session cookie is marked `Secure`.
+- **`TASKRR_TRUST_PROXY_HEADERS`** - leave it `true` behind a proxy so the real
+  client IP is read from `X-Forwarded-For` / `CF-Connecting-IP` for rate
+  limiting and logs. Set it to `false` only if Taskrr is exposed directly to the
+  internet, where those headers could be spoofed.
+
+When the connection is HTTPS - either directly (`TASKRR_COOKIE_SECURE=true`) or
+via a trusted proxy that sends `X-Forwarded-Proto: https` - Taskrr emits an HSTS
+header. Browsers ignore HSTS over plain HTTP, so it only takes effect on the
+encrypted leg.
+
+Taskrr also sets a strict Content-Security-Policy, `X-Frame-Options: DENY`,
+`X-Content-Type-Options: nosniff`, and `Referrer-Policy: same-origin` on every
+response. The app is same-origin only and embeds its own assets, so no extra CSP
+tuning is needed for a standard deployment.
+
+## Binding
+
+If the proxy runs on the same host, bind Taskrr to loopback so nothing else can
+reach it directly:
+
+```
+TASKRR_ADDR=127.0.0.1:8787
+```
+
+## Caddy
+
+Caddy obtains and renews certificates automatically:
+
+```caddyfile
+taskrr.example.com {
+    reverse_proxy 127.0.0.1:8787
+}
+```
+
+Set in Taskrr's environment:
+
+```
+TASKRR_COOKIE_SECURE=true
+TASKRR_TRUST_PROXY_HEADERS=true
+```
+
+Caddy forwards `X-Forwarded-Proto` and `X-Forwarded-For` by default.
+
+## Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name taskrr.example.com;
+
+    # ssl_certificate / ssl_certificate_key ...
+
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+## Traefik (Docker labels)
+
+```yaml
+labels:
+  - traefik.enable=true
+  - traefik.http.routers.taskrr.rule=Host(`taskrr.example.com`)
+  - traefik.http.routers.taskrr.entrypoints=websecure
+  - traefik.http.routers.taskrr.tls.certresolver=le
+  - traefik.http.services.taskrr.loadbalancer.server.port=8787
+```
+
+## Cloudflare Tunnel
+
+A tunnel terminates TLS at Cloudflare and sends `CF-Connecting-IP`. Keep
+`TASKRR_TRUST_PROXY_HEADERS=true` and `TASKRR_COOKIE_SECURE=true`. Point the
+tunnel's service at `http://127.0.0.1:8787`.
+
+## OIDC redirect URL behind a proxy
+
+Set `TASKRR_OIDC_REDIRECT_URL` (or the admin UI's redirect URL) to your public
+HTTPS origin plus the callback path, for example
+`https://taskrr.example.com/api/auth/oidc/callback`. It must match exactly what
+is registered with your identity provider. See
+[OIDC Single Sign-On](OIDC-Single-Sign-On).

--- a/wiki/Shared-Tasks.md
+++ b/wiki/Shared-Tasks.md
@@ -1,0 +1,64 @@
+# Shared Tasks
+
+Sharing lets two or more users see and log the same task - useful for a chore a
+household or team splits. The task stays a single record; members are attached to
+it, so everyone sees the same history and "who did it last".
+
+## Enabling sharing (admin)
+
+Sharing is gated by an instance setting, **Task sharing**, in the admin settings
+(the `tasks_shareable` setting). While it is off, the share controls are hidden
+and the server refuses new shares. An admin must turn it on before anyone can
+share. See the [Admin Guide](Admin-Guide).
+
+## How sharing works
+
+1. **Invite.** The owner invites another user by username. The invite waits as a
+   pending request.
+2. **Respond.** The recipient sees it in their **Requests** view, which shows a
+   calm accent pulse when something is waiting, and can **accept** or **decline**.
+3. **Collaborate.** Once accepted, the member can view the task, log completions,
+   and see the full history. Each completion records who logged it, and the card
+   shows who logged last.
+
+Only **accepted** membership counts: a task is badged as shared, appears for the
+member, and generates reminders for the member only after the invite is accepted -
+a pending invite alone does none of these.
+
+## Who can do what
+
+- **Owner** - edits and archives the task definition, invites members, and has
+  full control.
+- **Member** (accepted) - views the task, logs completions, edits their own
+  completions, and can leave at any time.
+- A completion can be edited or deleted by the **task owner** or by **whoever
+  logged it**.
+
+## Opting out of shares
+
+Each user can opt out of receiving shares in their account settings. When opted
+out, others cannot send them new share invites. This is enforced on the server,
+not just hidden in the UI.
+
+## Deletion is non-destructive
+
+Sharing makes "delete" safe for collaborators:
+
+- A **member** who deletes the task simply **leaves** it - their membership is
+  removed; the task and its history persist for everyone else.
+- When the **owner** deletes a task that still has accepted members, **ownership
+  transfers** to the earliest member, so the task and its complete history are
+  never lost.
+- Only when the owner deletes a task with **no** accepted members is the task
+  actually removed (along with its completions and any pending invitations).
+
+## Reminders for shared tasks
+
+If a shared task has a routine, every recipient who has reminders configured -
+the owner and each accepted member - is reminded independently for their own due
+cycle. See [Reminders](Reminders).
+
+## Not in the demo
+
+Sharing needs a second user and a real server, so it is not available in the
+in-browser [demo](https://unmaykr-a.github.io/taskrr/).

--- a/wiki/Tasks-and-Routines.md
+++ b/wiki/Tasks-and-Routines.md
@@ -1,0 +1,88 @@
+# Tasks and Routines
+
+A task in Taskrr is a recurring thing you want to keep track of - not a one-off
+to-do. The core idea is **how long it's been since you last did it**.
+
+## Logging a completion
+
+Each time you do the thing, log a completion:
+
+- **Quick log** records "done, now" in one tap.
+- **Advanced log** lets you pick a date and time and add a note - useful for
+  backfilling something you did yesterday, or recording context.
+
+Completions are an append-only history. The card counts up from the most recent
+one ("3 days ago"), and the most recent completion drives the staleness colour.
+
+### Editing history
+
+History is editable. Any logged completion can be changed (its time or note) or
+deleted later, so a mis-tap is easy to fix. On a [shared task](Shared-Tasks),
+each completion records who logged it, and the card shows who logged last; a
+completion can be edited by the task owner or by whoever logged it.
+
+## Routines (cadence) and due dates
+
+Give a task a routine - "every 2 weeks", "every 3 days" - and Taskrr treats it as
+having a due time: the last completion plus the interval.
+
+- The card shades **continuously from fresh (green) to overdue (red)** as the due
+  time approaches and passes.
+- A progress bar and a "due in 3d" / "overdue by 2d" label show where it stands.
+- Tasks with no routine simply age; they show time-since but are never "due".
+
+The exact colours and thresholds are tunable (see
+[Theming and Branding](Theming-and-Branding)). The colour logic lives in the
+frontend and is unit-tested; cadence and due-date maths are deterministic.
+
+### Per-task colours and freezing
+
+You can override the fresh and overdue colours per task. A task can also have its
+colour **frozen**, so it stays at its recent colour instead of fading over time -
+handy for things you want to keep visually calm. There is also a global "fade
+colours over time" preference that applies the same idea to every task at once.
+
+## Organising larger lists
+
+As the list grows, three tools keep it tidy:
+
+- **Tags** - attach labels to tasks, then filter with the search box or by
+  clicking a tag chip.
+- **Folders** - assign a task to a folder, and optionally switch on a grouping
+  mode that collapses the list into a section per folder.
+- **Sorting** - order by name, or by most / least recently done, from the
+  toolbar.
+
+## Filters and bulk actions
+
+The sidebar offers filter views with live counts:
+
+- **All** - everything active.
+- **Due soon** - has a routine and is approaching its due time.
+- **Overdue** - past its due time.
+- **Never done** - no completions yet.
+- **Archived** - soft-archived tasks (see below).
+
+Select several tasks to run a **bulk action**: log, archive, restore, or delete
+them together, with a confirmation that states the count.
+
+## Archiving vs deleting
+
+- **Archiving** soft-hides a task and its history without losing anything; it
+  moves to the Archived filter and can be restored at any time.
+- **Deleting** removes the task. For [shared tasks](Shared-Tasks) deletion is
+  non-destructive for collaborators - a member who deletes simply leaves, and an
+  owner deleting a task that still has members transfers ownership to the
+  earliest member so the history is never lost.
+
+## Calendar and activity
+
+- A **month calendar** shows what you did on each day and what is coming up
+  (upcoming due dates for routine tasks).
+- An **activity chart** summarises your completions over the last 30 days.
+
+## See also
+
+- [Shared Tasks](Shared-Tasks) - sharing a task with another user.
+- [Reminders](Reminders) - a webhook nudge when a task is due.
+- [Theming and Branding](Theming-and-Branding) - colours and the overall look.

--- a/wiki/Theming-and-Branding.md
+++ b/wiki/Theming-and-Branding.md
@@ -1,0 +1,71 @@
+# Theming and Branding
+
+Taskrr's interface is highly themeable per user, and admins can set an
+instance-wide default and brand the instance identity.
+
+## Per-user theming
+
+From the floating theme customiser (a settings window) each user can adjust:
+
+- **Colours** - an accent/colour picker with palette generation.
+- **Light and dark** modes.
+- **Fonts**.
+- **Animated backgrounds** and frosted-glass effects, with per-animation toggles
+  so you can dial motion up or down (handy on low-power hardware or for reduced
+  motion).
+- **Floating windows** for settings panels.
+
+Saved themes are stored per account on the server (not just in the browser), so
+they follow you across devices and survive sign-out.
+
+### Task colours
+
+Task staleness colours - the fresh-to-overdue shading - are tunable policy:
+
+- Set fresh and overdue colours **per task**, or globally.
+- **Freeze** a task's colour so it stays put instead of fading.
+- A global **"Fade colours over time"** preference applies the frozen behaviour
+  to every task at once.
+
+See [Tasks and Routines](Tasks-and-Routines).
+
+### Pickers
+
+Several input controls (colour wheel, date picker, time picker) can be switched
+between Taskrr's custom widgets and the device's native inputs in preferences,
+whichever you prefer.
+
+## Instance default theme (admin)
+
+Admins can publish a theme as the instance default:
+
+- **Set as site default** - the theme shown to everyone by default, including on
+  the signed-out login page.
+- **Use the default for everyone** - accounts that have not customised their own
+  theme follow the site default and pick up the admin's later changes. As soon as
+  a user changes their theme, theirs takes over - it is a default, not a lock.
+
+## Shared themes (admin)
+
+When **theme sharing** is enabled, a **Share** button publishes a saved theme to
+all users, where it appears in a Shared themes group and can be applied like a
+preset. Admins can unshare. An additional toggle lets non-admin users share
+themes too, not just admins.
+
+## Branding (admin)
+
+Customise the instance identity from the admin settings:
+
+- **Name** - shown in the sidebar and on the login card.
+- **Browser tab title** - sets the document title (defaults to the name when
+  blank).
+- **Tagline** - the small subtitle under the name.
+- **Icon** - an uploaded image, downscaled client-side to a small PNG and used
+  for the favicon, the sidebar mark, and the login card. Without one, Taskrr uses
+  a generated accent checkmark. Uploaded icons are validated as images and capped
+  in size on the server.
+- **Login card toggles** - hide the icon and/or the name and tagline on the login
+  page.
+
+Branding is delivered as part of the public auth config, so the **signed-out
+login page is branded too**.

--- a/wiki/Users-and-Authentication.md
+++ b/wiki/Users-and-Authentication.md
@@ -1,0 +1,77 @@
+# Users and Authentication
+
+Taskrr supports multiple users, each with their own private tasks and history.
+Sign-in is by local username and password, by OIDC single sign-on, or both.
+
+## The bootstrap admin
+
+On first start a single admin account is created (`TASKRR_ADMIN_USERNAME`,
+default `admin`). If you did not preset a password, you set it in the browser on
+the first sign-in. This account is protected - other admins cannot edit or delete
+it, and it always keeps password sign-in as a break-glass path. See
+[Configuration](Configuration).
+
+## Sessions
+
+A successful sign-in creates a session stored as a hashed token in a cookie.
+Sessions last `TASKRR_SESSION_TTL` (default `720h`) and **slide** - they renew
+while in use. Set `TASKRR_COOKIE_SECURE=true` when serving over HTTPS. Admins can
+see and terminate active sessions from the admin area.
+
+Sign-in is rate limited both per username and per source IP, so neither a focused
+account attack nor a password-spray across many usernames runs unbounded. For the
+per-IP limiter to see the real address behind a proxy, keep
+`TASKRR_TRUST_PROXY_HEADERS=true` (see [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS)).
+
+## Roles
+
+There are two roles:
+
+- **admin** - full access to the admin area (users, settings, backups, sessions,
+  logs, themes).
+- **user** - their own tasks, account, reminders, and shares.
+
+Admins manage roles from the admin area. There is always at least one admin.
+
+## Registration controls
+
+Self-registration is off by default and controlled by admin settings:
+
+- **Local registration** (`reg_local`) - allow username/password self sign-up.
+- **OIDC auto-provision** (`reg_oidc`) - create a user automatically on first
+  successful OIDC login.
+- **Approval queue** (`reg_approval`) - local sign-ups need admin approval before
+  they can sign in; pending users appear in the admin area to approve or deny.
+
+These live in the [Admin Guide](Admin-Guide).
+
+## Account self-service
+
+Every signed-in user can, from their account settings:
+
+- Change their **username**.
+- Change their **password**.
+- Connect or disconnect **OIDC** (link/unlink the SSO identity).
+- Manage **reminders** (see [Reminders](Reminders)).
+- Opt in or out of receiving **task shares** (see [Shared Tasks](Shared-Tasks)).
+- **Wipe my data** - delete their own tasks and history while keeping the account.
+- **Delete account** - remove the account entirely.
+
+## Lite mode
+
+Set `TASKRR_LITE=true` for a single-person instance. This turns off the
+multi-user surface: self-registration and creating extra accounts are disabled,
+and the Users section of the admin area is hidden. You still sign in normally; it
+just removes everything to do with managing other people.
+
+## Merging accounts
+
+If someone ends up with two accounts (for example a local account and a separate
+OIDC one), an admin can **merge** them: data can be moved from the source to the
+target, and the source is removed. This is handy when migrating users onto SSO.
+
+## See also
+
+- [OIDC Single Sign-On](OIDC-Single-Sign-On) - full SSO setup and role mapping.
+- [Admin Guide](Admin-Guide) - registration settings, approvals, and user
+  management.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+[Taskrr](https://github.com/unmaykr-a/taskrr) - a self-hosted tracker for when you last did things - [MIT](https://github.com/unmaykr-a/taskrr/blob/main/LICENSE) - [Support on Ko-fi](https://ko-fi.com/unmaykr)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,27 @@
+### Taskrr
+
+**Getting started**
+- [Home](Home)
+- [Installation](Installation)
+- [Configuration](Configuration)
+- [Reverse Proxy and HTTPS](Reverse-Proxy-and-HTTPS)
+
+**Using Taskrr**
+- [Tasks and Routines](Tasks-and-Routines)
+- [Shared Tasks](Shared-Tasks)
+- [Reminders](Reminders)
+- [Theming and Branding](Theming-and-Branding)
+
+**Accounts**
+- [Users and Authentication](Users-and-Authentication)
+- [OIDC Single Sign-On](OIDC-Single-Sign-On)
+
+**Administration**
+- [Admin Guide](Admin-Guide)
+- [Backups and Restore](Backups-and-Restore)
+
+**Reference**
+- [API Reference](API-Reference)
+- [Architecture](Architecture)
+- [Development and Contributing](Development-and-Contributing)
+- [FAQ and Troubleshooting](FAQ-and-Troubleshooting)

--- a/wiki/publish.sh
+++ b/wiki/publish.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Publish the Markdown pages in this folder to the GitHub wiki.
+#
+# The GitHub wiki is a separate git repository (<repo>.wiki.git) that this CI
+# environment cannot reach, so publishing is done from a machine that has GitHub
+# access (your laptop). Run this from the repository root:
+#
+#   bash wiki/publish.sh
+#
+# Prerequisites:
+#   - git, with push access to the repository's wiki.
+#   - The wiki must be initialised once (create any page in the GitHub web UI:
+#     repo -> Wiki -> Create the first page), otherwise the wiki repo does not
+#     exist yet and the clone below will fail.
+set -euo pipefail
+
+REPO_WIKI="https://github.com/unmaykr-a/taskrr.wiki.git"
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Cloning wiki: $REPO_WIKI"
+git clone "$REPO_WIKI" "$TMP_DIR/wiki"
+
+echo "Copying pages"
+cp "$SRC_DIR"/*.md "$TMP_DIR/wiki"/
+
+cd "$TMP_DIR/wiki"
+git add -A
+if git diff --cached --quiet; then
+  echo "No changes to publish."
+  exit 0
+fi
+git commit -m "Update wiki documentation"
+git push origin HEAD
+echo "Wiki updated."


### PR DESCRIPTION
## Project links in the changelog

The changelog dialog (opened from the version label) gains a footer with two
links, both opening in a new tab:

- **GitHub** -> `https://github.com/unmaykr-a/taskrr`
- **Support on Ko-fi** -> `https://ko-fi.com/unmaykr`

These render for all users (including the demo), styled as muted footer links
with lucide icons. Verified in a headless demo build: both links present with
correct `href`/`target`/`rel`, version reads `v1.13.0`, no page errors.

Version bumped to 1.13.0 (new user-facing addition) with a matching in-app
changelog entry. `tsc --noEmit` clean; Vitest 17/17 pass.

## Wiki documentation

Adds a complete documentation set under `wiki/`, written against the current
codebase (routes, env vars, settings, and feature behaviour), ready to publish to
the GitHub wiki:

- Home, Installation, Configuration, Reverse Proxy and HTTPS
- Tasks and Routines, Shared Tasks, Reminders, Theming and Branding
- Users and Authentication, OIDC Single Sign-On
- Admin Guide, Backups and Restore
- API Reference, Architecture, Development and Contributing, FAQ and Troubleshooting
- `_Sidebar.md` / `_Footer.md` for wiki navigation

### Publishing the wiki

This environment cannot reach the wiki repository (`taskrr.wiki.git`) - it is a
separate git repo outside the sandbox's network scope, and the GitHub API tooling
here does not cover wikis. So the pages are committed to the repo and published
from a machine with GitHub access:

1. Initialise the wiki once (repo -> Wiki -> create any first page) so
   `taskrr.wiki.git` exists.
2. From the repo root, run `bash wiki/publish.sh` - it clones the wiki, copies the
   pages, and pushes.

The `wiki/` folder can stay in the repo as the version-controlled source of the
wiki, or be removed after publishing - it does not affect the app build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_