### PR TITLE
In-app dialogs, full-height sidebar, smooth-scroll pause fix

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taskrr-web",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { useMediaQuery } from "@/lib/useMediaQuery";
 import { useNow } from "@/lib/useNow";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 import { Sidebar } from "@/components/Sidebar";
 import { RequestsView } from "@/components/RequestsView";
 import { TaskCard } from "@/components/TaskCard";
@@ -43,6 +44,7 @@ const OIDC_LINK_MESSAGES: Record<string, string> = {
 export default function App() {
   const now = useNow(); // ticking clock so staleness/counts refresh over time
   const { prefs, setPrefs } = usePrefs();
+  const { alert } = useConfirm();
   const queryClient = useQueryClient();
   const [filter, setFilter] = useState<Filter>("all");
   const [search, setSearch] = useState("");
@@ -57,8 +59,8 @@ export default function App() {
     const message = OIDC_LINK_MESSAGES[result] ?? OIDC_LINK_MESSAGES.error;
     if (result === "linked") queryClient.invalidateQueries({ queryKey: ["me"] });
     window.history.replaceState({}, "", window.location.pathname);
-    window.alert(message);
-  }, [queryClient]);
+    void alert({ title: "Single sign-on", description: message });
+  }, [queryClient, alert]);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [selectMode, setSelectMode] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(() => new Set());
@@ -224,12 +226,16 @@ export default function App() {
         {/* Sidebar: static column on large screens, off-canvas drawer when compact. */}
         <aside
           className={cn(
-            "fixed inset-y-0 left-0 z-50 transition-transform duration-300 ease-in-out will-change-transform",
+            "left-0 will-change-transform",
             compact
-              ? sidebarOpen
-                ? "translate-x-0"
-                : "-translate-x-full"
-              : "static z-auto translate-x-0",
+              ? cn(
+                  "fixed inset-y-0 z-50 transition-transform duration-300 ease-in-out",
+                  sidebarOpen ? "translate-x-0" : "-translate-x-full",
+                )
+              : // Desktop: stick to the top and always fill the viewport height, so
+                // the nav and footer stay in place instead of scrolling away with
+                // the page on shorter layouts.
+                "sticky top-0 z-auto h-[100dvh]",
           )}
         >
           <Sidebar

--- a/web/src/components/AdminPanel.tsx
+++ b/web/src/components/AdminPanel.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/AuthProvider";
 import { useWindows } from "@/components/windows/WindowManager";
 import { useToast } from "@/components/ui/Toast";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -377,6 +378,7 @@ function MergeAccounts() {
   const { user: me } = useAuth();
   const queryClient = useQueryClient();
   const toast = useToast();
+  const { confirm } = useConfirm();
   const { data: users } = useQuery({ queryKey: ["users"], queryFn: api.listUsers });
   const [sourceId, setSourceId] = useState<number | "">("");
   const [targetId, setTargetId] = useState<number | "">("");
@@ -410,16 +412,20 @@ function MergeAccounts() {
   const targetOptions = users.filter((u) => u.id !== sourceId && !u.protected);
   const ready = source && target && source.id !== target.id;
 
-  const confirmMerge = () => {
+  const confirmMerge = async () => {
     if (!ready) return;
     const kept = keepUsername === "source" ? source!.username : target!.username;
     const dataMsg = moveData ? `move "${source!.username}"'s tasks into "${target!.username}"` : `discard "${source!.username}"'s tasks`;
     if (
-      window.confirm(
-        `Merge "${source!.username}" into "${target!.username}"?\n\nThis will ${dataMsg}, move its sign-in ` +
+      await confirm({
+        title: "Merge accounts",
+        description:
+          `Merge "${source!.username}" into "${target!.username}"?\n\nThis will ${dataMsg}, move its sign-in ` +
           `(including any OIDC link) to "${target!.username}", keep the username "${kept}", and DELETE ` +
           `"${source!.username}". This can't be undone.`,
-      )
+        confirmText: "Merge",
+        destructive: true,
+      })
     ) {
       merge.mutate();
     }
@@ -505,6 +511,7 @@ function MergeAccounts() {
 function BackupsSection() {
   const queryClient = useQueryClient();
   const toast = useToast();
+  const { confirm } = useConfirm();
   const { data: backups } = useQuery({ queryKey: ["backups"], queryFn: api.listBackups });
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["backups"] });
   const create = useMutation({
@@ -544,12 +551,16 @@ function BackupsSection() {
     onError: (e) => setErr((e as Error).message),
   });
 
-  const confirmRestore = (label: string, run: () => void) => {
+  const confirmRestore = async (label: string, run: () => void) => {
     if (
-      window.confirm(
-        `Restore from ${label}?\n\nThis REPLACES all current data with the backup and restarts the server. ` +
+      await confirm({
+        title: "Restore backup",
+        description:
+          `Restore from ${label}?\n\nThis REPLACES all current data with the backup and restarts the server. ` +
           `A safety backup of the current data is taken first. Everyone is signed out.\n\nContinue?`,
-      )
+        confirmText: "Restore",
+        destructive: true,
+      })
     ) {
       run();
     }
@@ -625,8 +636,16 @@ function BackupsSection() {
                 type="button"
                 aria-label={`Delete backup ${b.name}`}
                 disabled={del.isPending}
-                onClick={() => {
-                  if (window.confirm(`Delete backup ${b.name}? This can't be undone.`)) del.mutate(b.name);
+                onClick={async () => {
+                  if (
+                    await confirm({
+                      title: "Delete backup",
+                      description: `Delete backup ${b.name}? This can't be undone.`,
+                      confirmText: "Delete",
+                      destructive: true,
+                    })
+                  )
+                    del.mutate(b.name);
                 }}
                 className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-destructive disabled:opacity-50"
               >
@@ -643,6 +662,7 @@ function BackupsSection() {
 /** Advanced: backups + a danger zone of irreversible, instance-wide deletions. */
 function AdvancedSettings() {
   const queryClient = useQueryClient();
+  const { confirm } = useConfirm();
   const [msg, setMsg] = useState<string | null>(null);
   const wipe = useMutation({
     mutationFn: (opts: { tasks?: boolean; users?: boolean; everything?: boolean }) => api.adminWipe(opts),
@@ -659,8 +679,15 @@ function AdvancedSettings() {
     },
     onError: (e) => setMsg((e as Error).message),
   });
-  const confirmWipe = (opts: { tasks?: boolean; users?: boolean; everything?: boolean }, label: string) => {
-    if (window.confirm(`This permanently deletes ${label}.\n\nThis cannot be undone. Continue?`)) {
+  const confirmWipe = async (opts: { tasks?: boolean; users?: boolean; everything?: boolean }, label: string) => {
+    if (
+      await confirm({
+        title: "Confirm deletion",
+        description: `This permanently deletes ${label}.\n\nThis cannot be undone. Continue?`,
+        confirmText: "Delete",
+        destructive: true,
+      })
+    ) {
       setMsg(null);
       wipe.mutate(opts);
     }
@@ -995,6 +1022,7 @@ function Users() {
   const { user: me } = useAuth();
   const queryClient = useQueryClient();
   const toast = useToast();
+  const { prompt } = useConfirm();
   const { data: users } = useQuery({ queryKey: ["users"], queryFn: api.listUsers });
   const invalidate = () => queryClient.invalidateQueries({ queryKey: ["users"] });
 
@@ -1027,8 +1055,14 @@ function Users() {
     },
   });
 
-  const resetPassword = (u: User) => {
-    const next = window.prompt(`New password for ${u.username} (min 8 chars):`);
+  const resetPassword = async (u: User) => {
+    const next = await prompt({
+      title: "Reset password",
+      description: `New password for ${u.username} (min 8 chars):`,
+      inputType: "password",
+      placeholder: "New password",
+      confirmText: "Set password",
+    });
     if (next) update.mutate({ id: u.id, password: next });
   };
 

--- a/web/src/components/settings/PreferencesSection.tsx
+++ b/web/src/components/settings/PreferencesSection.tsx
@@ -190,6 +190,15 @@ export function PreferencesSection() {
           />
         </label>
         <label className="flex items-center justify-between gap-2 text-sm">
+          <span className="text-muted-foreground">Use browser dialogs</span>
+          <input
+            type="checkbox"
+            className="h-4 w-4 accent-primary"
+            checked={prefs.nativeDialogs}
+            onChange={(e) => setPrefs({ nativeDialogs: e.target.checked })}
+          />
+        </label>
+        <label className="flex items-center justify-between gap-2 text-sm">
           <span className="text-muted-foreground">Show calendar</span>
           <input
             type="checkbox"

--- a/web/src/components/settings/ThemeCustomizer.tsx
+++ b/web/src/components/settings/ThemeCustomizer.tsx
@@ -24,6 +24,7 @@ import { ColorField } from "@/components/ui/ColorPicker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/Toast";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 
 const SELECT =
   "h-9 w-full rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -60,6 +61,7 @@ export function ThemeCustomizer() {
   const isAdmin = user?.role === "admin";
   const queryClient = useQueryClient();
   const toast = useToast();
+  const { alert } = useConfirm();
   const [name, setName] = useState("");
   const [harmony, setHarmony] = useState<Harmony>("complementary");
   const fileRef = useRef<HTMLInputElement>(null);
@@ -137,7 +139,7 @@ export function ThemeCustomizer() {
         applyTheme({ ...DEFAULT_THEME, ...(JSON.parse(text) as Theme) });
         toast("Theme imported", { tone: "success" });
       })
-      .catch(() => alert("That file isn't a valid Taskrr theme."));
+      .catch(() => void alert({ title: "Import failed", description: "That file isn't a valid Taskrr theme." }));
   }
 
   return (

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,187 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { usePrefs } from "@/lib/prefs";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// In-app confirm / prompt / alert dialogs, themed to match the rest of the app
+// instead of the browser's native pop-ups. Call them via useConfirm(); each
+// returns a Promise so call sites read like the blocking browser equivalents.
+//
+// A per-user preference (prefs.nativeDialogs) falls back to the real
+// window.confirm/prompt/alert for anyone who prefers them.
+
+interface BaseOptions {
+  /** Heading. Falls back to a sensible default per kind. */
+  title?: string;
+  /** Body text. Newlines are preserved. */
+  description?: string;
+  /** Confirm button label (default "Confirm", or "OK" for alert). */
+  confirmText?: string;
+  /** Cancel button label (default "Cancel"). */
+  cancelText?: string;
+  /** Style the confirm button as destructive (for deletes etc.). */
+  destructive?: boolean;
+}
+
+export type ConfirmOptions = BaseOptions;
+
+export interface PromptOptions extends BaseOptions {
+  defaultValue?: string;
+  placeholder?: string;
+  /** Input type, e.g. "text" (default) or "password". */
+  inputType?: string;
+}
+
+export interface ConfirmApi {
+  confirm: (opts?: ConfirmOptions) => Promise<boolean>;
+  prompt: (opts?: PromptOptions) => Promise<string | null>;
+  alert: (opts?: BaseOptions | string) => Promise<void>;
+}
+
+type Kind = "confirm" | "prompt" | "alert";
+
+interface Request {
+  id: number;
+  kind: Kind;
+  opts: PromptOptions;
+  resolve: (value: boolean | string | null | void) => void;
+}
+
+const Ctx = createContext<ConfirmApi | null>(null);
+
+/** Returns { confirm, prompt, alert }. Must be used under ConfirmProvider. */
+export function useConfirm(): ConfirmApi {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("useConfirm must be used within a ConfirmProvider");
+  return ctx;
+}
+
+/** Flatten a dialog's title + body into the single string a native pop-up takes. */
+function toText(opts: BaseOptions): string {
+  return [opts.title, opts.description].filter(Boolean).join("\n\n");
+}
+
+function defaultTitle(kind: Kind): string {
+  return kind === "alert" ? "Notice" : kind === "prompt" ? "Enter a value" : "Are you sure?";
+}
+
+let nextId = 1;
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const { prefs } = usePrefs();
+  // Read the latest preference at call time without re-creating the api callback.
+  const nativeRef = useRef(prefs.nativeDialogs);
+  nativeRef.current = prefs.nativeDialogs;
+
+  const [queue, setQueue] = useState<Request[]>([]);
+  const [value, setValue] = useState("");
+
+  const enqueue = useCallback((kind: Kind, opts: PromptOptions) => {
+    if (nativeRef.current) {
+      // Native fallback: the browser's own (synchronous) dialogs.
+      if (kind === "confirm") return Promise.resolve(window.confirm(toText(opts)));
+      if (kind === "prompt") return Promise.resolve(window.prompt(toText(opts), opts.defaultValue ?? ""));
+      window.alert(toText(opts));
+      return Promise.resolve(undefined);
+    }
+    return new Promise<boolean | string | null | void>((resolve) => {
+      const req: Request = { id: nextId++, kind, opts, resolve };
+      setQueue((q) => {
+        if (q.length === 0) setValue(opts.defaultValue ?? ""); // priming the input
+        return [...q, req];
+      });
+    });
+  }, []);
+
+  const api = useMemo<ConfirmApi>(
+    () => ({
+      confirm: (opts = {}) => enqueue("confirm", opts) as Promise<boolean>,
+      prompt: (opts = {}) => enqueue("prompt", opts) as Promise<string | null>,
+      alert: (opts = {}) =>
+        enqueue("alert", typeof opts === "string" ? { description: opts } : opts) as Promise<void>,
+    }),
+    [enqueue],
+  );
+
+  const active = queue[0];
+
+  const finish = (result: boolean | string | null | void) => {
+    if (!active) return;
+    active.resolve(result);
+    setQueue((q) => {
+      const next = q.slice(1);
+      if (next[0]) setValue(next[0].opts.defaultValue ?? "");
+      return next;
+    });
+  };
+
+  const onCancel = () =>
+    finish(active?.kind === "prompt" ? null : active?.kind === "confirm" ? false : undefined);
+  const onConfirm = () =>
+    finish(active?.kind === "prompt" ? value : active?.kind === "confirm" ? true : undefined);
+
+  return (
+    <Ctx.Provider value={api}>
+      {children}
+      <Dialog open={!!active} onOpenChange={(open) => !open && onCancel()}>
+        {active && (
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{active.opts.title ?? defaultTitle(active.kind)}</DialogTitle>
+              {active.opts.description && (
+                <DialogDescription className="whitespace-pre-line">
+                  {active.opts.description}
+                </DialogDescription>
+              )}
+            </DialogHeader>
+            {active.kind === "prompt" && (
+              <input
+                autoFocus
+                type={active.opts.inputType ?? "text"}
+                value={value}
+                placeholder={active.opts.placeholder}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    onConfirm();
+                  }
+                }}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            )}
+            <DialogFooter>
+              {active.kind !== "alert" && (
+                <Button variant="outline" onClick={onCancel}>
+                  {active.opts.cancelText ?? "Cancel"}
+                </Button>
+              )}
+              <Button
+                variant={active.opts.destructive ? "destructive" : "default"}
+                onClick={onConfirm}
+              >
+                {active.opts.confirmText ?? (active.kind === "alert" ? "OK" : "Confirm")}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+    </Ctx.Provider>
+  );
+}

--- a/web/src/lib/prefs.tsx
+++ b/web/src/lib/prefs.tsx
@@ -89,6 +89,9 @@ export interface Prefs {
   smoothScroll: boolean;
   /** Show brief toast notifications for actions (save, delete, log, …). */
   toasts: boolean;
+  /** Use the browser's native confirm/prompt/alert dialogs instead of the
+   *  in-app ones. Off by default (the in-app dialogs match the theme). */
+  nativeDialogs: boolean;
 
   // --- themes ---
   /** The user's saved named themes. Persisted server-side with the rest of
@@ -157,6 +160,7 @@ function defaults(): Prefs {
     animViews: true,
     smoothScroll: true,
     toasts: true,
+    nativeDialogs: false,
     savedThemes: [],
     themeCustom: false,
     draggableWindows: true,

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -37,6 +37,24 @@ const fix = (text: string, note?: string): Change => ({ text, kind: "fix", note 
 // Newest first. Keep the headline short; put the explanation in the note.
 export const RELEASES: Release[] = [
   {
+    version: "1.14.0",
+    date: "2026-06-16",
+    changes: [
+      feat(
+        "In-app dialogs",
+        "Confirmations and prompts now use themed in-app dialogs instead of the browser's pop-ups. Prefer the native ones? Turn on \"Use browser dialogs\" in Preferences.",
+      ),
+      fix(
+        "Sidebar height",
+        "On shorter desktop layouts the sidebar now stays put and fills the viewport instead of scrolling away with the page.",
+      ),
+      fix(
+        "Smooth scrolling",
+        "The end of a smooth scroll no longer flickers the animated background off and on when it pauses on scroll.",
+      ),
+    ],
+  },
+  {
     version: "1.13.0",
     date: "2026-06-16",
     changes: [

--- a/web/src/lib/smoothScroll.ts
+++ b/web/src/lib/smoothScroll.ts
@@ -70,7 +70,12 @@ export function installSmoothWheel(): () => void {
         return;
       }
       const diff = s.target - el.scrollTop;
-      if (Math.abs(diff) < 0.5) {
+      // Snap home once within a pixel. Below ~1px the per-frame step is so small
+      // that scrollTop's integer value changes only every few frames, so the
+      // scroll events spread out — and anything that debounces "is scrolling"
+      // (e.g. the background pausing on scroll) flickers off/on as the tail
+      // decelerates. Ending here keeps the events dense and the finish crisp.
+      if (Math.abs(diff) < 1) {
         el.scrollTop = s.target;
         states.delete(el);
         return;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "@/components/AuthProvider";
 import { PrefsProvider } from "@/lib/prefs";
 import { WindowManagerProvider } from "@/components/windows/WindowManager";
 import { ToastProvider } from "@/components/ui/Toast";
+import { ConfirmProvider } from "@/components/ui/ConfirmDialog";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -26,9 +27,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <PrefsProvider>
           <AuthProvider>
             <ToastProvider>
-              <WindowManagerProvider>
-                <Gate />
-              </WindowManagerProvider>
+              <ConfirmProvider>
+                <WindowManagerProvider>
+                  <Gate />
+                </WindowManagerProvider>
+              </ConfirmProvider>
             </ToastProvider>
           </AuthProvider>
         </PrefsProvider>


### PR DESCRIPTION
Three UI changes. Independent of #19 (different files).

## In-app confirm / prompt / alert dialogs

Adds a `ConfirmProvider` and `useConfirm()` (mirroring the existing toast pattern) that render themed in-app dialogs and return promises, so call sites read like the blocking browser equivalents:

```ts
if (await confirm({ title: "Delete backup", description: "...", destructive: true })) del.mutate(name);
const pw = await prompt({ title: "Reset password", inputType: "password" });
await alert({ title: "Single sign-on", description: message });
```

Replaced every `window.confirm` / `window.prompt` / `window.alert`:
- Admin panel: merge accounts, restore backup, delete backup, wipe (tasks/users/everything), reset user password.
- Theme import failure notice.
- The OIDC-link result notice in `App`.

A new **Use browser dialogs** preference (Preferences, off by default) makes `useConfirm` fall back to the real `window.*` dialogs for anyone who prefers them.

## Full-height sidebar

On medium desktop widths the sidebar was `static`, so scrolling the page scrolled the sidebar away — its nav slid off the top and the footer floated mid-screen (see the report). It's now `sticky top-0` and fills the viewport height, so the nav and footer stay put while the main content scrolls. Wide (side-by-side) and the mobile drawer are unchanged.

## Smooth-scroll background-pause flicker

With smooth scrolling and "pause background on scroll" both on, the end of a scroll flickered the animated background off and on. The eased tail crawls sub-pixel toward the target, so `scrollTop`'s integer value changes only every few frames near the end; those increasingly sparse scroll events cross the background's 160ms idle debounce, toggling its pause off/on repeatedly. The smooth-scroll loop now snaps home within 1px instead of crawling to 0.5px, keeping the scroll events dense through the finish. (1px is imperceptible.)

## Verification

- `tsc --noEmit` clean; Vitest 17/17 pass.
- Headless demo: sidebar at 962x789 after scrolling is `position: sticky`, top 0, full viewport height, with the brand and Settings both visible (was scrolling away before). The in-app dialog renders for the OIDC-link path and dismisses cleanly. No page errors.

Version 1.14.0 with a matching in-app changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_