### PR TITLE
Settings window divider spans full height

### DIFF
--- a/web/src/components/SettingsPanel.tsx
+++ b/web/src/components/SettingsPanel.tsx
@@ -31,7 +31,7 @@ export function SettingsPanel({ initial = "account" }: { initial?: Section }) {
   const active = visible.some((i) => i.id === section) ? section : "account";
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+    <div className="flex min-h-full flex-col gap-3 sm:flex-row sm:gap-4">
       {/* Phone: a horizontal tab strip across the top (the window is full-screen,
           so this frees the whole width for content). Desktop: a vertical side nav. */}
       <nav

--- a/web/src/lib/releases.ts
+++ b/web/src/lib/releases.ts
@@ -44,6 +44,10 @@ export const RELEASES: Release[] = [
         "Background pausing",
         "With smooth scrolling and pause-on-scroll both on, the animated background no longer flickers off and on at the end of a scroll. It now stays paused for the whole smooth scroll and resumes once.",
       ),
+      fix(
+        "Settings divider",
+        "The divider line in the settings window now runs the full height instead of stopping where the section's content ends.",
+      ),
     ],
   },
   {


### PR DESCRIPTION
PR #21 was merged at the background-flicker commit before this second fix was pushed to that branch, so the settings-divider fix never reached `main`. This re-applies it on top of `main`.

## Settings window divider stopped partway

The vertical divider between the settings nav (Account/Preferences/Theme) and the content is `sm:border-l` on the content column, which only spanned the content's height. When the window is taller than the active section (e.g. maximized or resized), the line stopped where the content ended. Giving the panel `min-h-full` makes the content column — and the divider — fill the window body.

Verified maximized: the content column now spans the full body height (was stopping at the content's end).

Part of 1.14.1 (already the current version on `main` from the flicker fix); this adds the matching changelog entry. `tsc` clean; Vitest 17/17 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBWv2VrWPVoKywsFWvt3PF)_